### PR TITLE
기존 메인페이지 그리드 비율 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
-
+.env
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,17 @@
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Main from './pages/main/Main';
+import Quest from './pages/Quest/Quest';
+import Ranking from './pages/Ranking/Ranking';
 function App() {
   return (
     <>
-      <Main></Main>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Main />}></Route>
+          <Route path="/quest" element={<Quest />}></Route>
+          <Route path="/Ranking" element={<Ranking />}></Route>
+        </Routes>
+      </BrowserRouter>
     </>
   );
 }

--- a/src/pages/Quest/Quest.tsx
+++ b/src/pages/Quest/Quest.tsx
@@ -1,15 +1,15 @@
-import { Link } from 'react-router-dom';
 import {
-  GridContainer,
   AlignCenter,
+  GridContainer,
   LayOutDiv,
   FeatureDiv,
 } from '../../style/LayOut';
-export default function Main() {
+import { Link } from 'react-router-dom';
+export default function Quest() {
   return (
     <AlignCenter>
       <GridContainer>
-        <LayOutDiv $height="100vh">
+        <LayOutDiv>
           <FeatureDiv $width="176px" $height="42px" $marginTop="50px">
             로고
           </FeatureDiv>
@@ -27,24 +27,17 @@ export default function Main() {
             )
           )}
         </LayOutDiv>
-        <LayOutDiv $height="100vh ">
-          <FeatureDiv $width="666px" $height="45px" $marginTop="98px">
-            진행도
+        <LayOutDiv>
+          <FeatureDiv $width="666px" $height="381px" $marginTop="98px">
+            오늘의 퀘스트 칸
           </FeatureDiv>
-          <FeatureDiv $width="666px" $height="105px" $marginTop="25px">
-            챕터 선택
-          </FeatureDiv>
-          <FeatureDiv $width="666px" $height="468px" $marginTop="25px">
-            챕터
+          <FeatureDiv $width="666px" $height="283px" $marginTop="24px">
+            메인 퀘스트 칸
           </FeatureDiv>
         </LayOutDiv>
-
-        <LayOutDiv $height="100vh">
+        <LayOutDiv>
           <FeatureDiv $width="294px" $height="42px" $marginTop="42px">
             생명력/프로필
-          </FeatureDiv>
-          <FeatureDiv $width="274px" $height="158px" $marginTop="47px">
-            일일 퀘스트
           </FeatureDiv>
         </LayOutDiv>
       </GridContainer>

--- a/src/pages/Ranking/Ranking.tsx
+++ b/src/pages/Ranking/Ranking.tsx
@@ -1,15 +1,16 @@
 import { Link } from 'react-router-dom';
 import {
-  GridContainer,
   AlignCenter,
+  GridContainer,
   LayOutDiv,
   FeatureDiv,
 } from '../../style/LayOut';
-export default function Main() {
+
+export default function Ranking() {
   return (
     <AlignCenter>
       <GridContainer>
-        <LayOutDiv $height="100vh">
+        <LayOutDiv>
           <FeatureDiv $width="176px" $height="42px" $marginTop="50px">
             로고
           </FeatureDiv>
@@ -27,24 +28,20 @@ export default function Main() {
             )
           )}
         </LayOutDiv>
-        <LayOutDiv $height="100vh ">
-          <FeatureDiv $width="666px" $height="45px" $marginTop="98px">
-            진행도
+        <LayOutDiv>
+          <FeatureDiv $width="666px" $height="338px" $marginTop="98px">
+            내 랭킹 칸
           </FeatureDiv>
-          <FeatureDiv $width="666px" $height="105px" $marginTop="25px">
-            챕터 선택
+          <FeatureDiv $width="666px" $height="28px" $marginTop="22px">
+            정렬기준
           </FeatureDiv>
-          <FeatureDiv $width="666px" $height="468px" $marginTop="25px">
-            챕터
+          <FeatureDiv $width="666px" $height="338px" $marginTop="22px">
+            다른 사람들 랭킹
           </FeatureDiv>
         </LayOutDiv>
-
-        <LayOutDiv $height="100vh">
+        <LayOutDiv>
           <FeatureDiv $width="294px" $height="42px" $marginTop="42px">
             생명력/프로필
-          </FeatureDiv>
-          <FeatureDiv $width="274px" $height="158px" $marginTop="47px">
-            일일 퀘스트
           </FeatureDiv>
         </LayOutDiv>
       </GridContainer>

--- a/src/style/LayOut.ts
+++ b/src/style/LayOut.ts
@@ -1,13 +1,25 @@
 import styled from 'styled-components';
-import { LayOut } from './type';
+import { LayOut } from '../types/LayOut';
 //아래 코드는 구역을 나누기 위한 것 일 뿐이니 나중에 지워도 됩니다
+export const GridContainer = styled.div`
+  display: grid;
+  width: 1280px;
+  margin: 0 62px;
+  grid-template-columns: 2fr 7fr 3fr;
+  column-gap: 20px;
+`;
+export const AlignCenter = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
 export const LayOutDiv = styled.div<LayOut>`
   display: flex;
   flex-direction: column;
   align-items: center;
   margin-top: ${({ $marginTop }) => $marginTop || '0px'};
-  height: ${({ $height }) => $height || '0px'};
-  background-color: ${({ $backGroundColor }) => $backGroundColor || 'gray'};
+  height: ${({ $height }) => $height || '100vh'};
+  background-color: ${({ $backGroundColor }) => $backGroundColor || '#fffff'};
 `;
 export const FeatureDiv = styled.div<LayOut>`
   width: ${({ $width }) => $width || '0px'};

--- a/src/style/gridSystem.ts
+++ b/src/style/gridSystem.ts
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-export const GridDiv = styled.div`
-  display: grid;
-  margin: 0 24px 0 24px;
-  grid-template-columns: 2fr 6fr 2fr;
-  column-gap: 24px;
-  grid-template-rows: 100vh;
-`;

--- a/src/types/LayOut.ts
+++ b/src/types/LayOut.ts
@@ -3,4 +3,5 @@ export interface LayOut {
   $height?: string;
   $width?: string;
   $backGroundColor?: string;
+  $gridColumn?: string;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
32
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
기존 10이였던 그리드를 12로 수정했습니다
![image](https://github.com/user-attachments/assets/3f8e6e2d-9317-45c6-9a2c-7701b2b55190)
각 비율을 2fr 7fr 3fr로 잡고 작업했고
각 요소 
![image](https://github.com/user-attachments/assets/f82ffdcf-9fe0-463a-81cd-0104d086505e)
이런 버튼, 로고 등등은 피그마를 참고해서 px로 작업 했습니다
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
개인적으로 아직도 저 12그리드로 디자인된거를 어떤식으로 css 옮길지 어느 부분에 어떤 단위를 사용할지 아직 확신이 안서네요
그런 부분 위주로 전체적으로 어떻게 하는게 좋을지 남겨주셨으면 좋겠습니다