### PR TITLE
ghcr 로그인 UserName 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.USERNAME }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Build and push
         id: docker_build
@@ -55,7 +55,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.USERNAME }}
+          username: ${{ github.actor  }}
           password: ${{ secrets.GHCR_TOKEN }}
       # 3000 -> 80 포트로 수행하도록 지정
       - name: Docker run


### PR DESCRIPTION
## 🔗 관련 이슈
#35 

<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
  원래는 깃허브 시크릿에 USERNAME이란 변수를 두고 그 안에 bluetree7878을 넣었습니다. 따라서 제가 디벨롭에 푸시했을 때 저와 로그인이 가능하도록 만들었습니다. 그러나 그렇게 하니 팀장님이 워크플로우를 실행시킬 때 빌드 과정에서 유저네임이 맞지 않으니 로그인이 안 되어 오류가 나타났습니다. 

  구글링을  해본 결과 github.actor 라고 쓰면 Workflow를 실행시킨 유저로 아이디가 들어간다고 합니다. 그거에 맞게 수정을 해봤습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] CICD 오류 수정

## 💬리뷰 요구사항 (선택사항)
