### PR TITLE
Vite @swc/plugin-styled-components 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@swc/plugin-styled-components": "^3.0.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react-swc": "^3.5.0",
@@ -1012,6 +1013,16 @@
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true
+    },
+    "node_modules/@swc/plugin-styled-components": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@swc/plugin-styled-components/-/plugin-styled-components-3.0.2.tgz",
+      "integrity": "sha512-ga3065ACLCHBfE3h6bsXABK3usFyqGr0BB/EWReGWu3igUinI6IqK50g76xEqcaEgF6ywM0cmrZ7ARqPPVOe+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
     },
     "node_modules/@swc/types": {
       "version": "0.1.12",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@swc/plugin-styled-components": "^3.0.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,5 +7,17 @@ export default defineConfig({
     host: '0.0.0.0',
     port: 3000,
   },
-  plugins: [react()],
+  plugins: [
+    react({
+      plugins: [
+        [
+          '@swc/plugin-styled-components',
+          {
+            displayName: true,
+            ssr: false,
+          },
+        ],
+      ],
+    }),
+  ],
 });


### PR DESCRIPTION
## 🔗 관련 이슈

#47 

## 📝작업 내용
![image](https://github.com/user-attachments/assets/6e3c2e2f-2c29-41d1-b1ac-f6cd70daed99)

npm install 하시면 @swc/plugin-styled-components 플러그인이 깔리게 됩니다.

이 플러그인으로 인해 개발자 도구로 스타일이 입혀진 곳을 확인해볼 때 위의 사진과 같이 파일명(스타일을 입힌) + 스타일드 컴포넌트명 + 해시값이 같이 출력 됩니다.

## 🔍 변경 사항

- [ ] 플러그인으로 Styled-componenst의 클래스명 변경

## 💬리뷰 요구사항 (선택사항)
저도 써보면서 안 건데 파일명도 같이 뜨네요. 좀 지저분해보일 수 있지만 해시값만 출력되는 것보단 이게 나은 것 같아요. 어떻게 생각하시는지 리뷰 달아주세용