### PR TITLE
로그인(Oauth) 페이지 레이아웃 완성

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,0 +1,17 @@
+import { AlignCenter } from '../../style/LayOut';
+import { FlexContainer, LogoImageSection, SocialLoginLink } from './styles';
+
+export default function Login() {
+  return (
+    <>
+      <AlignCenter>
+        <FlexContainer>
+          <LogoImageSection />
+          <SocialLoginLink to="">카카오</SocialLoginLink>
+          <SocialLoginLink to="">구글</SocialLoginLink>
+          <SocialLoginLink to="">깃허브</SocialLoginLink>
+        </FlexContainer>
+      </AlignCenter>
+    </>
+  );
+}

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -2,12 +2,15 @@ import { AlignCenter } from '../../style/LayOut';
 import { FlexContainer, LogoImageSection, SocialLoginLink } from './styles';
 
 export default function Login() {
+  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${
+    import.meta.env.VITE_KAKAO_REST_API_KEY
+  }&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URL}&response_type=code`;
   return (
     <>
       <AlignCenter>
         <FlexContainer>
           <LogoImageSection />
-          <SocialLoginLink to="">카카오</SocialLoginLink>
+          <SocialLoginLink to={kakaoURL}>카카오</SocialLoginLink>
           <SocialLoginLink to="">구글</SocialLoginLink>
           <SocialLoginLink to="">깃허브</SocialLoginLink>
         </FlexContainer>

--- a/src/pages/login/styles.ts
+++ b/src/pages/login/styles.ts
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+export const FlexContainer = styled.section`
+  width: 1280px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+export const LogoImageSection = styled.section`
+  margin: 163px 0px 70px 0px;
+  width: 372px;
+  height: 82px;
+  border: 2px dashed #f00;
+  background: #efeff0;
+`;
+export const SocialLoginLink = styled(Link)`
+  display: block;
+  margin-bottom: 45px;
+  width: 412px;
+  height: 50px;
+  color: black;
+  text-decoration: none; // 밑줄 없애기
+  border-radius: 4px;
+  border: 2px solid #000;
+  background: #fff;
+`;

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -5,6 +5,7 @@ import Ranking from '../pages/Ranking/Ranking';
 import Quiz from '../pages/Quiz/Quiz';
 import Admin from '../admin/Admin';
 import CreateQuiz from '../admin/CreateQuiz';
+import Login from '../pages/login/login';
 export default function Router() {
   return (
     <>
@@ -14,6 +15,7 @@ export default function Router() {
           <Route path="/quest" element={<Quest />}></Route>
           <Route path="/ranking" element={<Ranking />}></Route>
           <Route path="/quiz/:section/:part" element={<Quiz />}></Route>
+          <Route path="/login" element={<Login />}></Route>
           {/*어드민 페이지 부분 문제조회/추가 이외에 규모 확장 시 레포 분리 */}
           <Route path="/admin" element={<Admin />} />
           <Route path="/admin/create-quiz" element={<CreateQuiz />}></Route>


### PR DESCRIPTION
## 🔗 관련 이슈
54
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
![image](https://github.com/user-attachments/assets/82db0cad-57fd-4734-b46c-766b73f25703)
간단하게 소셜로그인 화면 레이아웃을 생성했습니다
![kakao_login_medium_wide](https://github.com/user-attachments/assets/3de0b739-79bf-4c4f-b8ee-a78e25c5f933)
각 디벨로퍼 사이트에서 이런식으로 이미지파일을 제공해줘서 나중에 s3에 업로드 후 각 로그인버튼에 넣으면 좋을 것 같습니다!
링크는 일단 우선순위가 높은 카카오 소셜로그인 링크를 달아놓았습니다. (아직 인증을 못받아서 에러가 뜨긴 합니다)


<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 로그인페이지 생성
- [ ] 카카오 로그인 링크


## 💬리뷰 요구사항 (선택사항)
