### PR TITLE
함수 수정, P테그 중첩 수정, usePreloadImage 에러메세지 수정

### DIFF
--- a/src/features/quiz/styles.ts
+++ b/src/features/quiz/styles.ts
@@ -263,7 +263,7 @@ export const DashLineHr = styled.hr`
     )
     1;
 `;
-export const TotalResultsTextBox = styled.p`
+export const TotalResultsTextDiv = styled.div`
   margin: 44px 0 17px 0;
   display: flex;
   font-size: 22px;

--- a/src/features/quiz/ui/TotalResults.tsx
+++ b/src/features/quiz/ui/TotalResults.tsx
@@ -6,7 +6,7 @@ import {
   LearnLink,
   TotalResultSection,
   TotalResultsImageDiv,
-  TotalResultsTextBox,
+  TotalResultsTextDiv,
 } from '../styles';
 const IMG_BASE_URL = import.meta.env.VITE_IMG_BASE_URL;
 
@@ -19,10 +19,10 @@ export default function TotalResults({ totalResults }: TotalResultsProps) {
   return (
     <>
       <TotalResultSection>
-        <TotalResultsTextBox>
+        <TotalResultsTextDiv>
           총<p>&nbsp; {totalResultCount}&nbsp;</p>
           문제를 맞혔고 <p>&nbsp;보상</p>을 얻었어!
-        </TotalResultsTextBox>
+        </TotalResultsTextDiv>
         <DashLineHr />
         <TotalResultsImageDiv>
           <ImageDescriptionDiv>

--- a/src/hooks/usePreloadImages.ts
+++ b/src/hooks/usePreloadImages.ts
@@ -34,7 +34,10 @@ const usePreloadImages = ({
       const rejectedValues = values.filter(
         value => value.status === 'rejected'
       );
-      console.error(rejectedValues);
+      if (rejectedValues.length > 0) {
+        console.error(rejectedValues);
+      }
+
       setIsLoading(false);
     });
   }, []);

--- a/src/utils/handlePage.ts
+++ b/src/utils/handlePage.ts
@@ -18,8 +18,9 @@ const handlePage = (
 ): void => {
   if (currentPage >= lastPage) {
     onFailure && onFailure();
+  } else {
+    onSuccess && onSuccess();
+    nextPage();
   }
-  onSuccess && onSuccess();
-  nextPage();
 };
 export default handlePage;


### PR DESCRIPTION
## 🔗 관련 이슈
#63
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
```ts
//기존
  if (currentPage >= lastPage) {
    onFailure && onFailure();
  } 
  onSuccess && onSuccess();
  nextPage();
 //수정 후
  if (currentPage >= lastPage) {
    onFailure && onFailure();
  } else {
    onSuccess && onSuccess();
    nextPage();
  }
```
조건에 맞지 않을때 페이지를 넘기면 안되는데 함수를 수정하면서 (#62) 수정을 잘못한 것 같습니다 `if-else` 를 사용해서 수정했습니다.
`TotalResults`컴포넌트에서 p테그안에 p테그가 들어있어 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

```ts
//기존
  if (currentPage >= lastPage) {
    onFailure && onFailure();
  } 
  onSuccess && onSuccess();
  nextPage();
 //수정 후
  if (currentPage >= lastPage) {
    onFailure && onFailure();
  } else {
    onSuccess && onSuccess();
    nextPage();
  }
```
조건에 맞지 않을때 페이지를 넘기면 안되는데 함수를 수정하면서 (#62) 수정을 잘못한 것 같습니다 `if-else` 를 사용해서 수정했습니다.
`TotalResults`컴포넌트에서 p테그안에 p테그가 들어있던 부분을 수정했습니다.
`usePreloadImages` 훅에서 모든 요소를 다 가져왔을때에도 에러 콘솔이 뜨던걸 `rejected`된 프로미스가 있을때에만 콘솔을 띄우도록 수정했습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ]handlePage 함수 수정
- [ ] TotalResults 컴포넌트 p테그 중첩 수정
- [ ] usePreloadImages 훅 에러메세지 출력 수정

## 💬리뷰 요구사항 (선택사항)
