### PR TITLE
CI/CD 워크플로우 및 Docker 액션 최신화

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,16 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # GitHub Repository에서 Checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Docker Buildx 설정
       - name: Set up docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Docker 캐시 설정
       - name: Cache docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ env.VERSION }}
@@ -36,7 +36,7 @@ jobs:
 
       # GitHub Container Registry 로그인
       - name: Login to ghcr
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
       # Docker Build 및 Push
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
@@ -62,7 +62,7 @@ jobs:
     steps:
       # GitHub Container Registry 로그인
       - name: Login to ghcr
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ jobs:
   # 빌드 Job
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # GitHub Repository에서 Checkout
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [deploy/#110/Update_CI/CD_Workflow]
+    branches: [main, develop]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy
@@ -15,7 +15,7 @@ jobs:
   # 빌드 Job
   build:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       # GitHub Repository에서 Checkout
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [main, develop]
+    branches: [deploy/#110/Update_CI/CD_Workflow]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Node.js 기반으로 빌드를 먼저 진행
-FROM node:22-alpine as build-stage
+FROM node:22-alpine AS build-stage
 
 ARG VITE_IMG_BASE_URL
 ARG VITE_BASE_URL

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
 import { createRoot } from 'react-dom/client';
-
 import App from './App.tsx';
+
 createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## 🔗 관련 이슈
#110 

## 📝작업 내용
Ubuntu 버전 24.04로 바꿔서 테스트를 해봤는데 아무런 문제가 없길래 원래처럼 latest 그대로 변경하지 않았습니다. 
변경하지 않으면 1월 17일에 Ubuntu 버전이 24.04(1월 17일 기준 최신)로 될 것입니다.
(관련 내용 [Ubuntu-latest workflows will use Ubuntu-24.04 image](https://github.com/actions/runner-images/issues/10636))

전반적으로 Action과 docker 버전을 높였습니다.
이렇게 변경 하니 #110 에 있던 "The save-state command is deprecated and will be disabled soon. Please upgrade to using Environment Files." 해당 경고문 또한 뜨지 않았습니다. (정확히는 setup-buildx-action 버전을 업그레이드 시킴으로써 경고문은 사라짐)

최종 버전 업그레이드
https://github.com/actions/checkout - v3 -> v4
https://github.com/docker/setup-buildx-action - v2 -> v3
https://github.com/actions/cache - v3 -> v4
https://github.com/docker/login-action - v1 -> v3
https://github.com/docker/build-push-action - v2 -> v6

![image](https://github.com/user-attachments/assets/e65105ab-b30f-4271-90fa-62ebe204a323)
docker/build-push-action의 버전을 업그레이드하니까 이런 식으로 빌드 과정이나 결과를 좀 더 세부적으로 볼 수 있게 돼서 좋은 것 같습니다 😲

## 🔍 변경 사항
- [ ] CI/CD(GitHub Actions) 버전 업그레이드

## 💬리뷰 요구사항 (선택사항)
