### PR TITLE
MenuBar 모바일 반응형 작업

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, publish/#114/MenuBar_Mobile_Layout]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [main, develop, publish/#114/MenuBar_Mobile_Layout]
+    branches: [main, develop]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy

--- a/src/common/layout/MenuBar.tsx
+++ b/src/common/layout/MenuBar.tsx
@@ -8,7 +8,7 @@ export default function MenuBar() {
   return (
     <MenuBox>
       <LogoBox>
-        <LogoImg src={getImageUrl('로고.svg')} />
+        <LogoImg src={getImageUrl('로고.svg')} alt="로고" />
       </LogoBox>
       {MENUS.map(menu => (
         <MenuItem

--- a/src/common/layout/styles.ts
+++ b/src/common/layout/styles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { animations } from '@/style/animations';
+import { media } from '@style/media';
 
 interface BaseStyleProps {
   $width?: string;
@@ -24,14 +25,30 @@ interface SortOptionLiProps extends BaseStyleProps {
   $height?: string;
 }
 
-export const MenuBox = styled.div`
+export const MenuBox = styled.nav`
   display: flex;
   flex-direction: column;
   gap: 40px;
   position: fixed;
+  z-index: 100;
   background-color: #fff1d9;
   border-right: 7px solid #ffe8c7;
   height: 100%;
+
+  ${media.mobile} {
+    flex-direction: row;
+    gap: 12px;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-right: none;
+    border-top: 5px solid #ffe8c7;
+    height: 82px;
+    width: 100%;
+    padding: 16px;
+    justify-content: space-between;
+    align-items: center;
+  }
 `;
 
 export const HeaderBox = styled.header`
@@ -50,6 +67,10 @@ export const HeaderBox = styled.header`
 export const LogoBox = styled.div`
   margin-top: 26px;
   margin-left: 39px;
+
+  ${media.mobile} {
+    display: none;
+  }
 `;
 
 export const OverRay = styled.div`

--- a/src/common/layout/styles.ts
+++ b/src/common/layout/styles.ts
@@ -66,7 +66,7 @@ export const HeaderBox = styled.header`
 
 export const LogoBox = styled.div`
   margin-top: 26px;
-  margin-left: 39px;
+  align-self: center;
 
   ${media.mobile} {
     display: none;

--- a/src/common/ui/MenuItem.tsx
+++ b/src/common/ui/MenuItem.tsx
@@ -1,5 +1,5 @@
 import * as S from './styles';
-import { getImageUrl } from '../../utils/getImageUrl';
+import { getImageUrl } from '@utils/getImageUrl';
 import { useLocation } from 'react-router-dom';
 
 interface MenuItem {
@@ -18,7 +18,7 @@ export default function MenuItem({ id, url, icon, title }: MenuItem) {
       <S.MenuLink to={`/${url}`}>
         <S.MenuButton $activeStyle={isActive}>
           <S.MenuIcon src={getImageUrl(icon)} alt={`${title} 아이콘`} />
-          {title}
+          <span>{title}</span>
         </S.MenuButton>
       </S.MenuLink>
     </S.MenuButtonWrapper>

--- a/src/common/ui/MenuItem.tsx
+++ b/src/common/ui/MenuItem.tsx
@@ -16,9 +16,9 @@ export default function MenuItem({ id, url, icon, title }: MenuItem) {
   return (
     <S.MenuButtonWrapper key={id}>
       <S.MenuLink to={`/${url}`}>
-        <S.MenuButton $activeStyle={isActive}>
+        <S.MenuButton $activeStyle={isActive} aria-label={title}>
           <S.MenuIcon src={getImageUrl(icon)} alt={`${title} 아이콘`} />
-          <span>{title}</span>
+          <strong>{title}</strong>
         </S.MenuButton>
       </S.MenuLink>
     </S.MenuButtonWrapper>

--- a/src/common/ui/styles.ts
+++ b/src/common/ui/styles.ts
@@ -46,10 +46,6 @@ export const MenuButton = styled.button<{ $activeStyle: boolean }>`
     padding: 0;
     gap: 0;
     justify-content: center;
-
-    span {
-      display: none;
-    }
   }
 `;
 

--- a/src/common/ui/styles.ts
+++ b/src/common/ui/styles.ts
@@ -8,20 +8,33 @@ interface UserInfoButtonProps {
   $boxShadow: string;
 }
 
-export const MenuButtonWrapper = styled.nav`
+export const MenuButtonWrapper = styled.div`
   display: inline-block;
 `;
 
-export const MenuButton = styled.button<{ $activeStyle: boolean }>`
+export const MenuLink = styled(Link)`
+  text-decoration: none;
+  display: block;
   width: 193px;
   height: 42px;
+  margin: 0 16px;
+
+  ${media.mobile} {
+    width: 48px;
+    height: 48px;
+    margin: 0;
+  }
+`;
+
+export const MenuButton = styled.button<{ $activeStyle: boolean }>`
+  width: 100%;
+  height: 100%;
   font-size: 15px;
   color: #fff;
   border-radius: 8px;
   border: 2px solid
     ${({ $activeStyle }) => ($activeStyle ? '#A69782' : '#FFE8C7')};
   background: ${({ $activeStyle }) => ($activeStyle ? '#D5B779' : '#F0D8A7')};
-  margin: 0 16px 0 16px;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -29,11 +42,8 @@ export const MenuButton = styled.button<{ $activeStyle: boolean }>`
   gap: 25px;
 
   ${media.mobile} {
-    width: 48px;
-    height: 48px;
     font-size: 0;
     padding: 0;
-    margin: 0;
     gap: 0;
     justify-content: center;
 
@@ -41,10 +51,6 @@ export const MenuButton = styled.button<{ $activeStyle: boolean }>`
       display: none;
     }
   }
-`;
-
-export const MenuLink = styled(Link)`
-  text-decoration: none;
 `;
 
 export const MenuIcon = styled.img`

--- a/src/common/ui/styles.ts
+++ b/src/common/ui/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@style/media';
 import { animations } from '@/style/animations';
 import { Link } from 'react-router-dom';
 
@@ -20,13 +21,25 @@ export const MenuButton = styled.button<{ $activeStyle: boolean }>`
   border: 2px solid
     ${({ $activeStyle }) => ($activeStyle ? '#A69782' : '#FFE8C7')};
   background: ${({ $activeStyle }) => ($activeStyle ? '#D5B779' : '#F0D8A7')};
-  margin-left: 16px;
-  margin-right: 20px;
+  margin: 0;
   display: flex;
   align-items: center;
   justify-content: flex-start;
   padding-left: 30px;
   gap: 25px;
+
+  ${media.mobile} {
+    width: 48px;
+    height: 48px;
+    font-size: 0;
+    padding: 0;
+    gap: 0;
+    justify-content: center;
+
+    span {
+      display: none;
+    }
+  }
 `;
 
 export const MenuLink = styled(Link)`
@@ -36,6 +49,11 @@ export const MenuLink = styled(Link)`
 export const MenuIcon = styled.img`
   width: 27px;
   height: 26px;
+
+  ${media.mobile} {
+    width: 40px;
+    height: 40px;
+  }
 `;
 
 export const IconWrapper = styled.div<{ $color: string }>`

--- a/src/common/ui/styles.ts
+++ b/src/common/ui/styles.ts
@@ -21,7 +21,7 @@ export const MenuButton = styled.button<{ $activeStyle: boolean }>`
   border: 2px solid
     ${({ $activeStyle }) => ($activeStyle ? '#A69782' : '#FFE8C7')};
   background: ${({ $activeStyle }) => ($activeStyle ? '#D5B779' : '#F0D8A7')};
-  margin: 0;
+  margin: 0 16px 0 16px;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -33,6 +33,7 @@ export const MenuButton = styled.button<{ $activeStyle: boolean }>`
     height: 48px;
     font-size: 0;
     padding: 0;
+    margin: 0;
     gap: 0;
     justify-content: center;
 

--- a/src/features/learn/ui/KeycapAdventureIntro.tsx
+++ b/src/features/learn/ui/KeycapAdventureIntro.tsx
@@ -28,8 +28,9 @@ export default function KeycapAdventureIntro({
     <>
       <S.LegendKeycapMessageImg
         src={getImageUrl(messageFileNames[messageIndex])}
+        alt={messageFileNames[messageIndex]}
       />
-      <S.HandsUpCokoImg src={getImageUrl('손든-코코.svg')} />
+      <S.HandsUpCokoImg src={getImageUrl('손든-코코.svg')} alt="손든 코코" />
     </>
   );
 }

--- a/src/features/quest/ui/DailyQuest.tsx
+++ b/src/features/quest/ui/DailyQuest.tsx
@@ -42,12 +42,18 @@ export default function DailyQuest() {
         const { progressBarColor, rewardIcon, progressBarIcon } =
           getDailyUIProps(quest.progress, quest.maxProgress);
 
+        const isComplete = quest.progress >= quest.maxProgress;
+
         return (
           <S.QuestWrapper key={quest.id} {...questUrlProps}>
             <S.QuestsTitle {...questUrlProps}>{quest.title}</S.QuestsTitle>
             <S.ProgressBarWrapper {...questUrlProps}>
               {progressBarIcon && (
-                <S.ProgressBarIcon src={progressBarIcon} {...questUrlProps} />
+                <S.ProgressBarIcon
+                  src={progressBarIcon}
+                  {...questUrlProps}
+                  alt="일일 퀘스트 도장"
+                />
               )}
               <ProgressBar
                 $progress={quest.progress}
@@ -58,7 +64,10 @@ export default function DailyQuest() {
                 $borderRadius="20px"
               />
               <S.RewardIconWrapper {...questUrlProps}>
-                <S.RewardIcon src={rewardIcon} />
+                <S.RewardIcon
+                  src={rewardIcon}
+                  alt={isComplete ? '일일 퀘스트 보상' : '일일 퀘스트 진행'}
+                />
               </S.RewardIconWrapper>
             </S.ProgressBarWrapper>
           </S.QuestWrapper>

--- a/src/features/quest/ui/MainQuest.tsx
+++ b/src/features/quest/ui/MainQuest.tsx
@@ -30,12 +30,18 @@ export default function MainQuest() {
         const { progressBarColor, rewardIcon, progressBarIcon } =
           getMainUIProps(quest.progress, quest.maxProgress);
 
+        const isComplete = quest.progress >= quest.maxProgress;
+
         return (
           <S.QuestWrapper key={quest.id} {...questUrlProps}>
             <S.QuestsTitle {...questUrlProps}>{quest.title}</S.QuestsTitle>
             <S.ProgressBarWrapper {...questUrlProps}>
               {progressBarIcon && (
-                <S.ProgressBarIcon src={progressBarIcon} {...questUrlProps} />
+                <S.ProgressBarIcon
+                  src={progressBarIcon}
+                  {...questUrlProps}
+                  alt="메인 퀘스트 도장"
+                />
               )}
               <ProgressBar
                 $progress={quest.progress}
@@ -47,7 +53,10 @@ export default function MainQuest() {
                 $borderRadius="20px"
               />
               <S.RewardIconWrapper {...questUrlProps}>
-                <S.RewardIcon src={rewardIcon} />
+                <S.RewardIcon
+                  src={rewardIcon}
+                  alt={isComplete ? '메인 퀘스트 보상' : '메인 퀘스트 진행'}
+                />
               </S.RewardIconWrapper>
             </S.ProgressBarWrapper>
           </S.QuestWrapper>

--- a/src/features/quest/ui/QuestSection.tsx
+++ b/src/features/quest/ui/QuestSection.tsx
@@ -24,6 +24,7 @@ export default function QuestSection({
             <S.QuestIcon
               src={getImageUrl('폭탄-아이콘.svg')}
               {...questUrlProps}
+              alt="폭탄 아이콘"
             />
             <S.QuestHeading {...questUrlProps}>{title}</S.QuestHeading>
           </S.QuestContent>

--- a/src/features/quiz/ui/PartNavContainer.tsx
+++ b/src/features/quiz/ui/PartNavContainer.tsx
@@ -87,7 +87,7 @@ export default function PartNavContainer({
                       onClick={e => e.stopPropagation()}
                       $bgColor={COLORS[(globalIndex % 4) + 1]}
                     >
-                      {part.name}
+                      <h3>{part.name}</h3>
                       <GoToQuizButton
                         onClick={() => {
                           navigate('/quiz', {

--- a/src/features/quiz/ui/styles.ts
+++ b/src/features/quiz/ui/styles.ts
@@ -508,9 +508,9 @@ export const SectionWrapper = styled.div`
 `;
 
 // 섹션 제목(이름)
-export const SectionTitle = styled.h4`
+export const SectionTitle = styled.h2`
   width: 693px;
-  font-size: 17px;
+  font-size: 20px;
   color: #ffffff;
   text-align: center;
   display: flex;
@@ -604,6 +604,10 @@ export const SpeechBubble = styled.div<{ $bgColor: string }>`
     border: 0.8em solid transparent;
     border-bottom-color: ${({ $bgColor }) => $bgColor};
     transform: translateX(-50%);
+  }
+  h3 {
+    font-size: 18px;
+    font-weight: 300;
   }
 `;
 

--- a/src/pages/learn/Learn.tsx
+++ b/src/pages/learn/Learn.tsx
@@ -1,6 +1,6 @@
 import * as globalS from '@style/styles';
 import { useMemo } from 'react';
-import { ScrollableContainer } from './styles';
+import { ScreenReaderOnlyTitle, ScrollableContainer } from './styles';
 import { useScrollVisibility } from '@hooks/useScrollVisibility';
 import MenuBar from '@common/layout/MenuBar';
 import Header from '@common/layout/Header';
@@ -49,6 +49,9 @@ export default function Learn() {
         </globalS.RightSection>
       </globalS.Wrapper>
       <globalS.Layout>
+        <ScreenReaderOnlyTitle>
+          코코와 함께 코딩 마스터하기!
+        </ScreenReaderOnlyTitle>
         <ProgressBar
           $progress={progress}
           $maxProgress={maxProgress}

--- a/src/pages/learn/styles.ts
+++ b/src/pages/learn/styles.ts
@@ -14,3 +14,15 @@ export const ScrollableContainer = styled.div<ScrollableContainerProps>`
   justify-content: center;
   align-items: center;
 `;
+
+export const ScreenReaderOnlyTitle = styled.h1`
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;


### PR DESCRIPTION
## 🔗 관련 이슈
#114 

## 📝작업 내용
![image](https://github.com/user-attachments/assets/9746fdda-6083-43d3-bf83-dedae292e6cd)
이건 learn 페이지 모바일 반응형 피그마로 작업이 된 디자인입니다.
아직 메뉴바 아이콘과 버튼에 대한 디자인이 따로 나오지 않아서 아이콘은 기존에 있는 것을 썼고 버튼이나 그 외 디자인은 "이런 식으로 디자인이 될 것 같다"라는 생각으로 최대한 데스크톱(+태블릿) 기준의 비슷한 디자인으로 작업했습니다.

![image](https://github.com/user-attachments/assets/e7fd4cf8-f689-46f9-a171-5b1bdc054712)
이것은 실제로 제 핸드폰(IPhon 13 Pro 기준)으로 확인해본 결과입니다.
다른 분들 폰으로도 확인해봤는데 잘 나오는 것 같습니다. 혹여나 문제가 있어보인다면 수정하겠습니다.

## 🔍 변경 사항

- [ ] MenuBar 모바일 반응형 작업

## 💬리뷰 요구사항 (선택사항)
디자인 및 반응형 구현에 개선 사항이 있다면 피드백 부탁드리겠습니다!