### PR TITLE
Learn 페이지 반응형(모바일) 작업

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, publish/#117/Responsive_Learn_Page]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [main, develop, publish/#117/Responsive_Learn_Page]
+    branches: [main, develop]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,6 @@ import QueryErrorBoundary from '@features/error/ui/QueryErrorBoundary';
 import { Suspense } from 'react';
 import Loader from '@common/layout/Loader';
 import Router from '@/route/Router';
-import { ErrorBoundary } from 'react-error-boundary';
-import NotFound from '@/features/error/ui/NotFound';
 
 function App() {
   useUserInitializer();

--- a/src/common/ui/styles.ts
+++ b/src/common/ui/styles.ts
@@ -47,6 +47,10 @@ export const MenuButton = styled.button<{ $activeStyle: boolean }>`
     gap: 0;
     justify-content: center;
   }
+
+  strong {
+    color: #5e4630;
+  }
 `;
 
 export const MenuIcon = styled.img`

--- a/src/features/error/ui/NotFound.tsx
+++ b/src/features/error/ui/NotFound.tsx
@@ -1,8 +1,9 @@
-import { FallbackProps } from 'react-error-boundary';
 import { Link } from 'react-router-dom';
+
 interface NotFoundProps {
   error?: Error;
 }
+
 export default function NotFound({ error }: NotFoundProps) {
   return (
     <div>

--- a/src/features/learn/constants.ts
+++ b/src/features/learn/constants.ts
@@ -12,4 +12,5 @@ export const PRELOAD_IMAGES = [
   '키캡2-선택.svg',
   '키캡3-선택.svg',
   '키캡4-선택.svg',
+  '앉은-코코.svg',
 ];

--- a/src/features/learn/constants.ts
+++ b/src/features/learn/constants.ts
@@ -12,5 +12,10 @@ export const PRELOAD_IMAGES = [
   '키캡2-선택.svg',
   '키캡3-선택.svg',
   '키캡4-선택.svg',
+  '섬1.svg',
+  '섬2.svg',
+  '섬3.svg',
+  '섬4.svg',
+  '섬5.svg',
   '앉은-코코.svg',
 ];

--- a/src/features/learn/types.ts
+++ b/src/features/learn/types.ts
@@ -1,14 +1,14 @@
 export interface Section {
   id: number;
   name: string;
-  part: Part[];
+  parts: Part[];
 }
 
 export interface Part {
   id: number;
   name: string;
   sectionId: number;
-  partStatus: PartStatus;
+  status: PartStatus;
 }
 
 export type PartStatus =

--- a/src/features/learn/ui/NavigationControl.tsx
+++ b/src/features/learn/ui/NavigationControl.tsx
@@ -22,7 +22,7 @@ export default function NavigationControl({
       {isLeft && (
         <>
           <S.ArrowButton onClick={onClick} $isHidden={isHidden}>
-            <img src={getImageUrl('왼쪽-화살표.svg')} alt="left arrow" />
+            <img src={getImageUrl('왼쪽-화살표.svg')} alt="왼쪽 화살표" />
           </S.ArrowButton>
           <S.CompassText $isHidden={isHidden}>{compassText}</S.CompassText>
         </>
@@ -31,7 +31,7 @@ export default function NavigationControl({
         <>
           <S.CompassText $isHidden={isHidden}>{compassText}</S.CompassText>
           <S.ArrowButton onClick={onClick} $isHidden={isHidden}>
-            <img src={getImageUrl('오른쪽-화살표.svg')} alt="right arrow" />
+            <img src={getImageUrl('오른쪽-화살표.svg')} alt="오른쪽 화살표" />
           </S.ArrowButton>
         </>
       )}

--- a/src/features/learn/ui/SectionNavigateContainer.tsx
+++ b/src/features/learn/ui/SectionNavigateContainer.tsx
@@ -4,8 +4,12 @@ import type { Section } from '@features/learn/types';
 
 export default function SectionNavigateContainer({
   sections,
+  currentPage,
+  itemsPerPage,
 }: {
   sections: Section[];
+  currentPage: number;
+  itemsPerPage: number;
 }) {
   const scrollToSection = (sectionId: number) => {
     const targetSection = document.getElementById(`section-${sectionId}`);
@@ -16,15 +20,27 @@ export default function SectionNavigateContainer({
 
   return (
     <>
-      {sections.map((section, index) => (
-        <S.SectionButton
-          key={section.id}
-          $backgroundImage={getImageUrl(`섬${(index % 5) + 1}.svg`)}
-          onClick={() => scrollToSection(section.id)}
-        >
-          {section.name}
-        </S.SectionButton>
-      ))}
+      <S.SelectSectionImage
+        src={getImageUrl('섹션-선택-섬.svg')}
+        alt="섹션 선택 배경"
+      />
+      <S.SectionButtonContainer>
+        {sections.map((section, index) => {
+          const globalIndex = currentPage * itemsPerPage + index;
+          return (
+            <S.SectionButton
+              key={section.id}
+              onClick={() => scrollToSection(section.id)}
+            >
+              <img
+                src={getImageUrl(`섬${(globalIndex % 5) + 1}.svg`)}
+                alt={`${section.name} 섹션 이미지`}
+              />
+              <span>{section.name}</span>
+            </S.SectionButton>
+          );
+        })}
+      </S.SectionButtonContainer>
     </>
   );
 }

--- a/src/features/learn/ui/SelectSection.tsx
+++ b/src/features/learn/ui/SelectSection.tsx
@@ -10,9 +10,9 @@ export default function SelectSection() {
   const [currentPage, setCurrentPage] = useState(0);
 
   const sectionList = (sections as Section[]) || []; // 섹션 데이터를 Section 타입 배열로 변환 (섹션 리스트)
-  const ITEMS_PER_PAGE = 5; // 페이지당 항목(섹션) 수
+  const ITEMS_PER_PAGE = 3; // 페이지당 항목(섹션) 수
 
-  // 전체 페이지 수 계산 (한 페이지당 5개의 섹션)
+  // 전체 페이지 수 계산
   const totalPages = useMemo(
     () => Math.ceil(sectionList.length / ITEMS_PER_PAGE),
     [sectionList]
@@ -45,7 +45,11 @@ export default function SelectSection() {
         compassText="W"
       />
       <S.SelectSectionBox>
-        <SectionNavigateContainer sections={currentSections} />
+        <SectionNavigateContainer
+          sections={currentSections}
+          currentPage={currentPage}
+          itemsPerPage={ITEMS_PER_PAGE}
+        />
       </S.SelectSectionBox>
       <NavigationControl
         direction="right"

--- a/src/features/learn/ui/SelectSection.tsx
+++ b/src/features/learn/ui/SelectSection.tsx
@@ -3,29 +3,31 @@ import { useState, useMemo } from 'react';
 import NavigationControl from './NavigationControl';
 import SectionNavigateContainer from './SectionNavigateContainer';
 import { sectionsQuery } from '@features/learn/queries';
+import { useMediaQuery } from '@modern-kit/react';
+import { mediaQueryMap } from '@style/mediaQueryMap';
 import type { Section } from '@features/learn/types';
 
 export default function SelectSection() {
   const { data: sections } = sectionsQuery.getAll();
   const [currentPage, setCurrentPage] = useState(0);
-
+  const isMobile = useMediaQuery(mediaQueryMap.mobile);
+  const itemsPerPage = isMobile ? 3 : 5;
   const sectionList = (sections as Section[]) || []; // 섹션 데이터를 Section 타입 배열로 변환 (섹션 리스트)
-  const ITEMS_PER_PAGE = 3; // 페이지당 항목(섹션) 수
 
   // 전체 페이지 수 계산
   const totalPages = useMemo(
-    () => Math.ceil(sectionList.length / ITEMS_PER_PAGE),
-    [sectionList]
+    () => Math.ceil(sectionList.length / itemsPerPage),
+    [sectionList, itemsPerPage]
   );
 
   // 현재 페이지에 보여줄 섹션 리스트 계산
   const currentSections = useMemo(
     () =>
       sectionList.slice(
-        currentPage * ITEMS_PER_PAGE,
-        (currentPage + 1) * ITEMS_PER_PAGE
+        currentPage * itemsPerPage,
+        (currentPage + 1) * itemsPerPage
       ),
-    [currentPage, sectionList]
+    [currentPage, sectionList, itemsPerPage]
   );
 
   const goToPreviousPage = () => {
@@ -48,7 +50,7 @@ export default function SelectSection() {
         <SectionNavigateContainer
           sections={currentSections}
           currentPage={currentPage}
-          itemsPerPage={ITEMS_PER_PAGE}
+          itemsPerPage={itemsPerPage}
         />
       </S.SelectSectionBox>
       <NavigationControl

--- a/src/features/learn/ui/styles.ts
+++ b/src/features/learn/ui/styles.ts
@@ -28,8 +28,8 @@ export const SelectSectionBox = styled.div`
     max-width: 599px;
     height: calc((100vw - 80px) * 0.33);
     max-height: 197px;
-    min-width: 350px;
-    min-height: 130px;
+    min-width: 240px;
+    min-height: 80px;
   }
 `;
 
@@ -54,7 +54,6 @@ export const SectionButtonContainer = styled.div`
   z-index: 2;
 
   ${media.mobile} {
-    gap: 5px;
   }
 `;
 

--- a/src/features/learn/ui/styles.ts
+++ b/src/features/learn/ui/styles.ts
@@ -65,13 +65,18 @@ export const SectionButton = styled.button`
   border: none;
   background: none;
   padding: 10px;
+  width: 100px;
+  height: 120px;
 
   img {
-    width: 100%;
-    height: auto;
-    max-width: 80px;
-    max-height: 80px;
+    width: 80px;
+    height: 80px;
+
     ${media.mobile} {
+      width: calc((100vw - 80px) * 0.15);
+      height: calc((100vw - 80px) * 0.15);
+      min-width: 40px;
+      min-height: 40px;
       max-width: 70px;
       max-height: 70px;
     }

--- a/src/features/learn/ui/styles.ts
+++ b/src/features/learn/ui/styles.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { media } from '@style/media';
-import { getImageUrl } from '@/utils/getImageUrl';
 
 export const SectionBoxWrapper = styled.div`
   display: flex;
@@ -8,26 +7,87 @@ export const SectionBoxWrapper = styled.div`
   justify-content: space-between;
   width: 100%;
   margin-top: 45px;
+
+  ${media.mobile} {
+    margin-top: 65px;
+    gap: 5px;
+  }
 `;
 
-export const SectionButton = styled.button<{ $backgroundImage: string }>`
-  width: 100px;
-  height: 75px;
-  margin-top: 75px;
-  background: none;
-  border: none;
-  background-image: url(${({ $backgroundImage }) => $backgroundImage});
-`;
-
-export const SelectSectionBox = styled.section`
-  display: flex;
-  justify-content: center;
-  gap: 10px;
+export const SelectSectionBox = styled.div`
+  position: relative;
   width: 599px;
   height: 197px;
   margin-top: 30px;
-  background-image: url(${getImageUrl('섹션-선택-섬.svg')});
-  background-repeat: no-repeat;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${media.mobile} {
+    width: 390px;
+    height: 130px;
+  }
+`;
+
+export const SelectSectionImage = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 1;
+`;
+
+export const SectionButtonContainer = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+
+  ${media.mobile} {
+    gap: 5px;
+  }
+`;
+
+export const SectionButton = styled.button`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  padding: 10px;
+
+  img {
+    width: 100%;
+    height: auto;
+    max-width: 80px;
+    max-height: 80px;
+    ${media.mobile} {
+      max-width: 70px;
+      max-height: 70px;
+    }
+  }
+
+  span {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #333;
+
+    ${media.mobile} {
+      font-size: 12px;
+    }
+  }
+
+  &:hover {
+    transform: scale(1.1);
+    transition: transform 0.2s ease-in-out;
+  }
 `;
 
 export const ArrowButton = styled.button<{
@@ -41,9 +101,20 @@ export const ArrowButton = styled.button<{
   visibility: ${({ $isHidden }) => ($isHidden ? 'hidden' : 'visible')};
   pointer-events: ${({ $isHidden }) => ($isHidden ? 'none' : 'auto')};
 
+  ${media.mobile} {
+    width: 18px;
+    height: 18px;
+    margin-top: 50px;
+  }
+
   img {
     width: 25px;
     height: 25px;
+
+    ${media.mobile} {
+      width: 18px;
+      height: 18px;
+    }
   }
 `;
 
@@ -53,6 +124,10 @@ export const CompassText = styled.p<{ $isHidden: boolean }>`
   margin: 80px 10px 0 10px;
   visibility: ${({ $isHidden }) => ($isHidden ? 'hidden' : 'visible')};
   pointer-events: ${({ $isHidden }) => ($isHidden ? 'none' : 'auto')};
+
+  ${media.mobile} {
+    display: none;
+  }
 `;
 
 export const LegendKeycapMessageImg = styled.img`

--- a/src/features/learn/ui/styles.ts
+++ b/src/features/learn/ui/styles.ts
@@ -24,8 +24,12 @@ export const SelectSectionBox = styled.div`
   align-items: center;
 
   ${media.mobile} {
-    width: 390px;
-    height: 130px;
+    width: calc(100vw - 80px);
+    max-width: 599px;
+    height: calc((100vw - 80px) * 0.33);
+    max-height: 197px;
+    min-width: 350px;
+    min-height: 130px;
   }
 `;
 
@@ -75,7 +79,7 @@ export const SectionButton = styled.button`
   }
 
   span {
-    margin-top: 8px;
+    margin-top: 3px;
     font-size: 14px;
     color: #333;
 

--- a/src/features/learn/ui/styles.ts
+++ b/src/features/learn/ui/styles.ts
@@ -42,8 +42,8 @@ export const ArrowButton = styled.button<{
   pointer-events: ${({ $isHidden }) => ($isHidden ? 'none' : 'auto')};
 
   img {
-    width: 100%;
-    height: auto;
+    width: 25px;
+    height: 25px;
   }
 `;
 

--- a/src/features/quiz/ui/PartNavContainer.tsx
+++ b/src/features/quiz/ui/PartNavContainer.tsx
@@ -14,7 +14,7 @@ import {
 import { getImageUrl } from '@utils/getImageUrl';
 import { COLORS } from '../constants.ts';
 import getPartGridPosition from '@features/learn/service/getPartGridPosition';
-import { useRef } from 'react';
+import { useRef, useState, useEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import usePopover from '@hooks/usePopover';
 import type { Section } from '@/features/learn/types.ts';
@@ -29,6 +29,7 @@ export default function PartNavContainer({
   previousPartsCounts,
 }: PartNavContainerProps) {
   const navigate = useNavigate();
+  const [hasActiveBubble, setHasActiveBubble] = useState(false);
 
   if (!section) return <div>데이터가 없습니다.</div>;
 
@@ -38,28 +39,43 @@ export default function PartNavContainer({
   return (
     <>
       <UpperBackgroundImg />
-      <EntireSectionContainer>
+      <EntireSectionContainer $hasActiveBubble={hasActiveBubble}>
         <SectionWrapper id={`section-${section.id}`} key={section.id}>
           <SectionTitle>{section.name}</SectionTitle>
           <QuizTutorialLinkWrapper>
-            <Link to="/quiz/tutorial">퀴즈 튜토리얼 </Link>
+            <Link to="/quiz/tutorial">퀴즈 튜토리얼</Link>
           </QuizTutorialLinkWrapper>
 
           <ButtonGrid>
-            {section.part.map((part, partIndex) => {
+            {section.parts.map((part, partIndex) => {
               const globalIndex = previousPartsCount + partIndex;
               const { gridColumn, gridRow } = getPartGridPosition(globalIndex);
+
+              // 마지막 버튼인지 확인
+              const isLastButton = useMemo(
+                () => partIndex === section.parts.length - 1,
+                [partIndex, section.parts.length]
+              );
 
               const keyboardButtonWrapperRef = useRef<HTMLDivElement>(null);
               const { isOpen, togglePopover, popoverRef } = usePopover({
                 excludeRefs: [keyboardButtonWrapperRef],
               });
 
-              const buttonImage = getImageUrl(
-                isOpen
-                  ? `키캡${(globalIndex % 4) + 1}-선택.svg`
-                  : `키캡${(globalIndex % 4) + 1}.svg`
-              );
+              // 마지막 버튼인 경우, isOpen의 상태가 변경될 때만 setHasActiveBubble을 업데이트
+              useEffect(() => {
+                if (isLastButton) {
+                  setHasActiveBubble(prev => (prev !== isOpen ? isOpen : prev));
+                }
+              }, [isOpen, isLastButton]);
+
+              // KeyboardButton 클릭 시 팝오버(말풍선) 열림/닫힘
+              const handleButtonClick = () => {
+                togglePopover();
+                if (isLastButton) {
+                  setHasActiveBubble(prev => !prev);
+                }
+              };
 
               return (
                 <KeyboardButtonWrapper
@@ -76,13 +92,15 @@ export default function PartNavContainer({
                       alt="앉은 코코"
                     />
                   )}
-                  {/* KeyboardButton 클릭 시 팝오버(말풍선) 열림/닫힘 */}
-                  <KeyboardButton
-                    onClick={() => {
-                      togglePopover();
-                    }}
-                  >
-                    <img src={buttonImage} alt={`키캡 ${part.name}`} />
+                  <KeyboardButton onClick={handleButtonClick}>
+                    <img
+                      src={getImageUrl(
+                        isOpen
+                          ? `키캡${(globalIndex % 4) + 1}-선택.svg`
+                          : `키캡${(globalIndex % 4) + 1}.svg`
+                      )}
+                      alt={`키캡 ${part.name}`}
+                    />
                   </KeyboardButton>
 
                   {/* 말풍선 */}
@@ -96,7 +114,7 @@ export default function PartNavContainer({
                       <GoToQuizButton
                         onClick={() => {
                           navigate('/quiz', {
-                            state: { partId: part.id, status: part.partStatus },
+                            state: { partId: part.id, status: part.status },
                           });
                         }}
                         $fontColor={COLORS[(globalIndex % 4) + 1]}

--- a/src/features/quiz/ui/PartNavContainer.tsx
+++ b/src/features/quiz/ui/PartNavContainer.tsx
@@ -2,6 +2,7 @@ import {
   UpperBackgroundImg,
   EntireSectionContainer,
   SectionWrapper,
+  QuizTutorialLinkWrapper,
   SectionTitle,
   ButtonGrid,
   KeyboardButtonWrapper,
@@ -40,8 +41,11 @@ export default function PartNavContainer({
       <EntireSectionContainer>
         <SectionWrapper id={`section-${section.id}`} key={section.id}>
           <SectionTitle>{section.name}</SectionTitle>
+          <QuizTutorialLinkWrapper>
+            <Link to="/quiz/tutorial">퀴즈 튜토리얼 </Link>
+          </QuizTutorialLinkWrapper>
+
           <ButtonGrid>
-            <Link to="/quiz/tutorial">튜토리얼하실레오?</Link>
             {section.part.map((part, partIndex) => {
               const globalIndex = previousPartsCount + partIndex;
               const { gridColumn, gridRow } = getPartGridPosition(globalIndex);

--- a/src/features/quiz/ui/PartNavContainer.tsx
+++ b/src/features/quiz/ui/PartNavContainer.tsx
@@ -29,7 +29,7 @@ export default function PartNavContainer({
   previousPartsCounts,
 }: PartNavContainerProps) {
   const navigate = useNavigate();
-  const [hasActiveBubble, setHasActiveBubble] = useState(false);
+  const [isActiveBubble, setIsActiveBubble] = useState(false);
 
   if (!section) return <div>데이터가 없습니다.</div>;
 
@@ -39,7 +39,7 @@ export default function PartNavContainer({
   return (
     <>
       <UpperBackgroundImg />
-      <EntireSectionContainer $hasActiveBubble={hasActiveBubble}>
+      <EntireSectionContainer $isActiveBubble={isActiveBubble}>
         <SectionWrapper id={`section-${section.id}`} key={section.id}>
           <SectionTitle>{section.name}</SectionTitle>
           <QuizTutorialLinkWrapper>
@@ -62,10 +62,10 @@ export default function PartNavContainer({
                 excludeRefs: [keyboardButtonWrapperRef],
               });
 
-              // 마지막 버튼인 경우, isOpen의 상태가 변경될 때만 setHasActiveBubble을 업데이트
+              // 마지막 버튼인 경우, isOpen의 상태가 변경될 때만 setIsActiveBubble을 업데이트
               useEffect(() => {
                 if (isLastButton) {
-                  setHasActiveBubble(prev => (prev !== isOpen ? isOpen : prev));
+                  setIsActiveBubble(prev => (prev !== isOpen ? isOpen : prev));
                 }
               }, [isOpen, isLastButton]);
 
@@ -73,7 +73,7 @@ export default function PartNavContainer({
               const handleButtonClick = () => {
                 togglePopover();
                 if (isLastButton) {
-                  setHasActiveBubble(prev => !prev);
+                  setIsActiveBubble(prev => !prev);
                 }
               };
 

--- a/src/features/quiz/ui/PartNavContainer.tsx
+++ b/src/features/quiz/ui/PartNavContainer.tsx
@@ -77,6 +77,12 @@ export default function PartNavContainer({
                 }
               };
 
+              const buttonImage = getImageUrl(
+                isOpen
+                  ? `키캡${(globalIndex % 4) + 1}-선택.svg`
+                  : `키캡${(globalIndex % 4) + 1}.svg`
+              );
+
               return (
                 <KeyboardButtonWrapper
                   key={part.id}
@@ -93,14 +99,7 @@ export default function PartNavContainer({
                     />
                   )}
                   <KeyboardButton onClick={handleButtonClick}>
-                    <img
-                      src={getImageUrl(
-                        isOpen
-                          ? `키캡${(globalIndex % 4) + 1}-선택.svg`
-                          : `키캡${(globalIndex % 4) + 1}.svg`
-                      )}
-                      alt={`키캡 ${part.name}`}
-                    />
+                    <img src={buttonImage} alt={`키캡 ${part.name}`} />
                   </KeyboardButton>
 
                   {/* 말풍선 */}

--- a/src/features/quiz/ui/styles.ts
+++ b/src/features/quiz/ui/styles.ts
@@ -497,17 +497,17 @@ export const UpperBackgroundImg = styled.div`
 
 // 버튼 섹션 전체를 감싸는 Wrapper (백그라운드 이미지 고정)
 export const EntireSectionContainer = styled.div<{
-  $hasActiveBubble?: boolean;
+  $isActiveBubble?: boolean;
 }>`
   background-image: url(${imgUrl}배경2.webp);
-  padding-bottom: ${({ $hasActiveBubble }) =>
-    $hasActiveBubble ? '80px' : '0px'};
+  padding-bottom: ${({ $isActiveBubble }) =>
+    $isActiveBubble ? '80px' : '0px'};
   transition: margin-bottom 0.3s ease;
 
   ${media.mobile} {
     background-image: none;
-    padding-bottom: ${({ $hasActiveBubble }) =>
-      $hasActiveBubble ? '160px' : '60px'};
+    padding-bottom: ${({ $isActiveBubble }) =>
+      $isActiveBubble ? '160px' : '60px'};
   }
 `;
 

--- a/src/features/quiz/ui/styles.ts
+++ b/src/features/quiz/ui/styles.ts
@@ -1,6 +1,7 @@
 import styled, { css, keyframes } from 'styled-components';
 import { media } from '@style/media';
 import { getImageUrl } from '@utils/getImageUrl';
+import { animations } from '@style/animations';
 import type { Quiz } from '@features/quiz/types';
 
 const imgUrl = import.meta.env.VITE_IMG_BASE_URL;
@@ -488,16 +489,31 @@ export const UpperBackgroundImg = styled.div`
   background-image: url(${imgUrl}배경1.webp);
   display: flex;
   align-items: end;
+
+  ${media.mobile} {
+    display: none;
+  }
 `;
 
 // 버튼 섹션 전체를 감싸는 Wrapper (백그라운드 이미지 고정)
 export const EntireSectionContainer = styled.div`
   background-image: url(${imgUrl}배경2.webp);
+  ${media.mobile} {
+    background-image: none;
+    margin-bottom: 60px;
+  }
 `;
 
 // 섹션 하나를 감싸는 Wrapper
 export const SectionWrapper = styled.div`
   padding-bottom: 20px;
+`;
+
+// 퀴즈 튜토리얼 링크 감싸는 Wrapper
+export const QuizTutorialLinkWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
 `;
 
 // 섹션 제목(이름)
@@ -510,6 +526,10 @@ export const SectionTitle = styled.h2`
   align-items: center;
   justify-content: center;
 
+  ${media.mobile} {
+    color: #5f5f5f;
+  }
+
   &::before,
   &::after {
     content: '';
@@ -518,6 +538,12 @@ export const SectionTitle = styled.h2`
     background: #ffffff;
     margin: 0 55px;
     max-width: 200px;
+
+    ${media.mobile} {
+      background: #5f5f5f;
+      margin: 0 35px;
+      max-width: 120px;
+    }
   }
 `;
 
@@ -525,22 +551,15 @@ export const SectionTitle = styled.h2`
 export const ButtonGrid = styled.section`
   display: grid;
   grid-template-columns: repeat(5, 1fr);
+  ${media.mobile} {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 `;
 
 export const KeyboardButtonWrapper = styled.div`
   position: relative;
-`;
-
-// 앉은-코코 이미지 애니메이션 keyframes 정의
-const fadeInAndDrop = keyframes`
-  0% {
-    opacity: 0; /* 완전히 투명 */
-    transform: translate(-50%, -20px); /* 위쪽에서 시작 */
-  }
-  100% {
-    opacity: 1; /* 불투명 */
-    transform: translate(-50%, 0); /* 최종 위치 */
-  }
 `;
 
 // 앉은-코코 이미지
@@ -552,7 +571,7 @@ export const SittingCoko = styled.img`
   z-index: 5;
   width: 147px;
   height: 120px;
-  animation: ${fadeInAndDrop} 0.3s ease-out forwards;
+  animation: ${animations.fadeInAndDrop} 0.3s ease-out forwards;
 `;
 
 // 키캡(키보드 스위치) 버튼

--- a/src/features/quiz/ui/styles.ts
+++ b/src/features/quiz/ui/styles.ts
@@ -606,6 +606,7 @@ export const SpeechBubble = styled.div<{ $bgColor: string }>`
   align-items: center;
   left: 50%;
   transform: translateX(-50%);
+
   &:after {
     content: '';
     position: absolute;
@@ -617,9 +618,27 @@ export const SpeechBubble = styled.div<{ $bgColor: string }>`
     border-bottom-color: ${({ $bgColor }) => $bgColor};
     transform: translateX(-50%);
   }
+
   h3 {
     font-size: 18px;
     font-weight: 300;
+  }
+
+  ${media.mobile} {
+    width: 110px;
+    padding: 0.6em 0.8em;
+    bottom: 30px;
+    left: auto;
+    right: -120px;
+    transform: none;
+
+    &:after {
+      display: none;
+    }
+
+    h3 {
+      font-size: 16px;
+    }
   }
 `;
 

--- a/src/features/quiz/ui/styles.ts
+++ b/src/features/quiz/ui/styles.ts
@@ -528,6 +528,9 @@ export const SectionTitle = styled.h2`
 
   ${media.mobile} {
     color: #5f5f5f;
+    font-size: 20px;
+    max-width: 693px;
+    width: 100%;
   }
 
   &::before,

--- a/src/features/quiz/ui/styles.ts
+++ b/src/features/quiz/ui/styles.ts
@@ -496,11 +496,18 @@ export const UpperBackgroundImg = styled.div`
 `;
 
 // 버튼 섹션 전체를 감싸는 Wrapper (백그라운드 이미지 고정)
-export const EntireSectionContainer = styled.div`
+export const EntireSectionContainer = styled.div<{
+  $hasActiveBubble?: boolean;
+}>`
   background-image: url(${imgUrl}배경2.webp);
+  padding-bottom: ${({ $hasActiveBubble }) =>
+    $hasActiveBubble ? '80px' : '0px'};
+  transition: margin-bottom 0.3s ease;
+
   ${media.mobile} {
     background-image: none;
-    margin-bottom: 60px;
+    padding-bottom: ${({ $hasActiveBubble }) =>
+      $hasActiveBubble ? '160px' : '60px'};
   }
 `;
 
@@ -630,13 +637,16 @@ export const SpeechBubble = styled.div<{ $bgColor: string }>`
   ${media.mobile} {
     width: 110px;
     padding: 0.6em 0.8em;
-    bottom: 30px;
-    left: auto;
-    right: -120px;
-    transform: none;
+    top: calc(90%);
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
 
     &:after {
-      display: none;
+      display: block;
+      top: -20px;
+      border-bottom-color: ${({ $bgColor }) => $bgColor};
+      border-top-color: transparent;
     }
 
     h3 {

--- a/src/pages/learn/Learn.tsx
+++ b/src/pages/learn/Learn.tsx
@@ -1,6 +1,6 @@
 import * as globalS from '@style/styles';
+import * as S from './styles';
 import { useMemo } from 'react';
-import { QuizBox, ScreenReaderOnlyTitle, ScrollableContainer } from './styles';
 import { useScrollVisibility } from '@hooks/useScrollVisibility';
 import MenuBar from '@common/layout/MenuBar';
 import Header from '@common/layout/Header';
@@ -49,27 +49,28 @@ export default function Learn() {
         </globalS.RightSection>
       </globalS.Wrapper>
       <globalS.Layout>
-        <ScreenReaderOnlyTitle>
+        <S.ScreenReaderOnlyTitle>
           코코와 함께 코딩 마스터하기!
-        </ScreenReaderOnlyTitle>
-        <ProgressBar
-          $progress={progress}
-          $maxProgress={maxProgress}
-          $maxWidth="639px"
-          $height="16px"
-          $boxBgColor="#85705F"
-          $innerBgColor="#BFD683"
-          style={{ position: 'fixed', marginTop: '36px' }}
-        />
-        <ScrollableContainer $show={showComponents}>
+        </S.ScreenReaderOnlyTitle>
+        <S.ProgressBarWrapper>
+          <ProgressBar
+            $progress={progress}
+            $maxProgress={maxProgress}
+            $maxWidth="639px"
+            $height="16px"
+            $boxBgColor="#85705F"
+            $innerBgColor="#BFD683"
+          />
+        </S.ProgressBarWrapper>
+        <S.ScrollableContainer $show={showComponents}>
           <SelectSection />
-        </ScrollableContainer>
-        <QuizBox>
+        </S.ScrollableContainer>
+        <S.SectionGroup>
           <PartNavContainer
             section={section}
             previousPartsCounts={previousPartsCounts}
           />
-        </QuizBox>
+        </S.SectionGroup>
       </globalS.Layout>
     </>
   );

--- a/src/pages/learn/Learn.tsx
+++ b/src/pages/learn/Learn.tsx
@@ -22,12 +22,12 @@ export default function Learn() {
 
   // 이전 버튼 수 누적 계산
   const previousPartsCounts = useMemo(() => {
-    if (!section || !section.part) return [];
+    if (!section || !section.parts) return [];
     const counts: number[] = [];
     let sum = 0;
 
     counts.push(sum);
-    sum += section.part.length;
+    sum += section.parts.length;
 
     return counts;
   }, [section]);

--- a/src/pages/learn/styles.ts
+++ b/src/pages/learn/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@style/media';
 
 interface ScrollableContainerProps {
   $show: boolean;
@@ -15,8 +16,7 @@ export const ScrollableContainer = styled.div<ScrollableContainerProps>`
   align-items: center;
 `;
 
-// Learn 페이지 퀴즈들 감싸는 박스
-export const QuizBox = styled.div`
+export const SectionGroup = styled.div`
   width: 693px;
   margin-top: 270px;
   border: none;
@@ -32,4 +32,19 @@ export const ScreenReaderOnlyTitle = styled.h1`
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+`;
+
+export const ProgressBarWrapper = styled.div`
+  position: fixed;
+  top: 36px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: 639px;
+
+  ${media.mobile} {
+    top: 60px;
+    margin: 0 50px;
+    width: calc(100% - 100px);
+  }
 `;

--- a/src/pages/learn/styles.ts
+++ b/src/pages/learn/styles.ts
@@ -20,6 +20,13 @@ export const SectionGroup = styled.div`
   width: 693px;
   margin-top: 270px;
   border: none;
+
+  ${media.mobile} {
+    width: 100%;
+    max-width: 693px;
+    padding: 0 20px;
+    margin-top: 200px;
+  }
 `;
 
 export const ScreenReaderOnlyTitle = styled.h1`

--- a/src/pages/ranking/styles.ts
+++ b/src/pages/ranking/styles.ts
@@ -6,7 +6,6 @@ export const BarrelTopCokoImg = styled.img`
   height: 150px;
   margin: 99px 87px;
   position: fixed;
-  z-index: 1;
 `;
 
 export const BarrelContainer = styled.div<{ $rank: number | null }>`
@@ -14,6 +13,7 @@ export const BarrelContainer = styled.div<{ $rank: number | null }>`
   height: 155px;
   margin: 237px 87px;
   position: fixed;
+  z-index: -1;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/src/style/animations.ts
+++ b/src/style/animations.ts
@@ -17,6 +17,10 @@ export const animations = {
     0% { transform: translateX(-100%); opacity: 0; }
     100% { transform: translateX(0); opacity: 1; }
   `,
+  fadeInAndDrop: keyframes`
+    0% { opacity: 0; transform: translate(-50%, -20px); }
+    100% { opacity: 1; transform: translate(-50%, 0); }
+  `,
   fadeOutScaleDown: keyframes`
     0% { opacity: 1; transform: scale(1); }
     100% { opacity: 0; transform: scale(0.9); }

--- a/src/style/mediaQueryMap.ts
+++ b/src/style/mediaQueryMap.ts
@@ -1,0 +1,5 @@
+export const mediaQueryMap: Record<string, string> = {
+  mobile: '(max-width: 768px)',
+  tablet: '(min-width: 769px) and (max-width: 1279px)',
+  desktop: '(min-width: 1280px)',
+};

--- a/src/style/mediaQueryMap.ts
+++ b/src/style/mediaQueryMap.ts
@@ -1,5 +1,5 @@
-export const mediaQueryMap: Record<string, string> = {
+export const mediaQueryMap = {
   mobile: '(max-width: 768px)',
   tablet: '(min-width: 769px) and (max-width: 1279px)',
   desktop: '(min-width: 1280px)',
-};
+} as const;


### PR DESCRIPTION
## 🔗 관련 이슈
#117 

## 📝작업 내용
### Learn 페이지 모바일 화면 (IPhoe 13 pro 기준)
![image](https://github.com/user-attachments/assets/4a4d2953-57f1-47f5-9cb4-2eac563eafcb)

원래 이슈에서는 출석체크 버튼까지 구현하려고 했으나, 반응형에서 모달을 어떻게 띄울지에 대한 구체적인 설계가 필요하다고 생각해서 이를 별도의 이슈에서 처리하기로 결정했습니다.

## 🔍 변경 사항

- [x] 전체적인 Learn 페이지 반응형 (모바일 기준) 작업
- [x] 마지막 버튼 팝오버 열림/닫힘 시 EntireSectionContainer padding-bottom 동적 조정
- [x] itemsPerPage를 화면 크기에 따라 동적으로 변경 ([@modern-kit/useMediaQuery](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useMediaQuery/index.ts) 훅 사용)
- [x] 접근성 향상을 위해 MenuButton 텍스트 색상 대비 조정

## 💬리뷰 요구사항 (선택사항)
```tsx
// src/features/quiz/ui/PartNavContainer.tsx
const [hasActiveBubble, setHasActiveBubble] = useState(false);

<EntireSectionContainer $hasActiveBubble={hasActiveBubble}>
...
useEffect(() => {
  if (isLastButton) {
    setHasActiveBubble((prev) => (prev !== isOpen ? isOpen : prev));
  }
}, [isOpen, isLastButton]);

const handleButtonClick = () => {
  togglePopover();
  if (isLastButton) {
    setHasActiveBubble((prev) => !prev);
  }
};
...
```
```tsx
// src/features/quiz/ui/styles.ts
// 버튼 섹션 전체를 감싸는 Wrapper (백그라운드 이미지 고정)
export const EntireSectionContainer = styled.div<{
  $hasActiveBubble?: boolean;
}>`
  background-image: url(${imgUrl}배경2.webp);
  padding-bottom: ${({ $hasActiveBubble }) =>
    $hasActiveBubble ? '80px' : '0px'};
  transition: margin-bottom 0.3s ease;

  ${media.mobile} {
    background-image: none;
    padding-bottom: ${({ $hasActiveBubble }) =>
      $hasActiveBubble ? '160px' : '60px'};
  }
`;
```
현재 useState와 useEffect를 사용하여 EntireSectionContainer의 padding-bottom을 동적으로 조정하고 있습니다. 하지만 팝오버의 상태(isOpen)를 동기화하는 더 나은 방법(예: useRef로 직접 DOM 요소의 크기를 추적하는 방식)이 있다면 추가적인 피드백 부탁드립니다.

++ 현재 padding-bottom이 말풍선의 크기 따라 커지는 게 아니라 고정적인 값이라 수정할 것 같습니다.