### PR TITLE
api, 쿼리 키 수정

### DIFF
--- a/src/features/user/apis.ts
+++ b/src/features/user/apis.ts
@@ -47,7 +47,7 @@ const usersApis = {
     return response.data;
   },
 
-  patchPartProgress: async (params: {
+  patchPartStatus: async (params: {
     partId: Quiz['partId'];
     partStatus: PartStatus;
   }) => {
@@ -56,7 +56,7 @@ const usersApis = {
       status: partStatus,
     });
   },
-  patchCompletedPartProgress: async (params: { partId: Quiz['partId'] }) => {
+  patchCompletedPartStatus: async (params: { partId: Quiz['partId'] }) => {
     await api.patch(`/users/me/parts/${params.partId}/status/completed`);
   },
 

--- a/src/features/user/apis.ts
+++ b/src/features/user/apis.ts
@@ -52,7 +52,7 @@ const usersApis = {
     partStatus: PartStatus;
   }) => {
     const { partId, partStatus } = params;
-    await api.put(`/users/me/part-progress/parts/${partId}`, {
+    await api.patch(`/users/me/parts/${partId}/status`, {
       status: partStatus,
     });
   },

--- a/src/features/user/apis.ts
+++ b/src/features/user/apis.ts
@@ -47,7 +47,7 @@ const usersApis = {
     return response.data;
   },
 
-  putPartProgress: async (params: {
+  patchPartProgress: async (params: {
     partId: Quiz['partId'];
     partStatus: PartStatus;
   }) => {
@@ -55,6 +55,9 @@ const usersApis = {
     await api.patch(`/users/me/parts/${partId}/status`, {
       status: partStatus,
     });
+  },
+  patchCompletedPartProgress: async (params: { partId: Quiz['partId'] }) => {
+    await api.patch(`/users/me/parts/${params.partId}/status/completed`);
   },
 
   getHp: async (): Promise<UserHp> => {

--- a/src/features/user/queries.ts
+++ b/src/features/user/queries.ts
@@ -130,19 +130,19 @@ export const useUserPointQuery = {
 };
 
 export const useUserPartProgressQuery = {
-  updatePartProgress: () => {
+  updatePartStatus: () => {
     const queryClient = useQueryClient();
     return useMutation({
-      mutationFn: usersApis.patchPartProgress,
+      mutationFn: usersApis.patchPartStatus,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
       },
     });
   },
-  updateCompletedPartProgress: () => {
+  updateCompletedPartStatus: () => {
     const queryClient = useQueryClient();
     return useMutation({
-      mutationFn: usersApis.patchCompletedPartProgress,
+      mutationFn: usersApis.patchCompletedPartStatus,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
       },

--- a/src/features/user/queries.ts
+++ b/src/features/user/queries.ts
@@ -133,7 +133,16 @@ export const useUserPartProgressQuery = {
   updatePartProgress: () => {
     const queryClient = useQueryClient();
     return useMutation({
-      mutationFn: usersApis.putPartProgress,
+      mutationFn: usersApis.patchPartProgress,
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
+      },
+    });
+  },
+  updateCompletedPartProgress: () => {
+    const queryClient = useQueryClient();
+    return useMutation({
+      mutationFn: usersApis.patchCompletedPartProgress,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
       },

--- a/src/features/user/ui/PartClear.tsx
+++ b/src/features/user/ui/PartClear.tsx
@@ -4,9 +4,7 @@ import {
   useUserPartProgressQuery,
   useUserPointQuery,
 } from '@features/user/queries';
-import useUserStore from '@store/useUserStore';
 import { getImageUrl } from '@utils/getImageUrl';
-import { User } from '@/features/user/types';
 import { DEFAULT_POINT } from '@/features/user/constants';
 interface PartClearProps {
   partId: number;
@@ -15,14 +13,13 @@ export default function PartClear({ partId }: PartClearProps) {
   const { mutate: updatePoint, isIdle: isPointIdle } =
     useUserPointQuery.updatePoint();
   const { mutate: updatePartProgress, isIdle: isProgressIdle } =
-    useUserPartProgressQuery.updatePartProgress();
+    useUserPartProgressQuery.updateCompletedPartProgress();
   const navigate = useNavigate();
   const handleNavigateToLearn = () => {
     updatePoint({ point: DEFAULT_POINT });
 
     updatePartProgress({
       partId,
-      partStatus: 'COMPLETED',
     });
 
     navigate('/learn');

--- a/src/features/user/ui/PartClear.tsx
+++ b/src/features/user/ui/PartClear.tsx
@@ -12,13 +12,13 @@ interface PartClearProps {
 export default function PartClear({ partId }: PartClearProps) {
   const { mutate: updatePoint, isIdle: isPointIdle } =
     useUserPointQuery.updatePoint();
-  const { mutate: updatePartProgress, isIdle: isProgressIdle } =
-    useUserPartProgressQuery.updateCompletedPartProgress();
+  const { mutate: updatePartStatus, isIdle: isProgressIdle } =
+    useUserPartProgressQuery.updateCompletedPartStatus();
   const navigate = useNavigate();
   const handleNavigateToLearn = () => {
     updatePoint({ point: DEFAULT_POINT });
 
-    updatePartProgress({
+    updatePartStatus({
       partId,
     });
 

--- a/src/features/user/ui/TotalResults.tsx
+++ b/src/features/user/ui/TotalResults.tsx
@@ -31,8 +31,8 @@ export default function TotalResults({
     useUserExperienceQuery.getExperience();
   const { mutate: experienceUpdate, isIdle: isExperienceIdle } =
     useUserExperienceQuery.updateExperience();
-  const { mutate: updateProgress, isIdle: isProgressIdle } =
-    useUserPartProgressQuery.updatePartProgress();
+  const { mutate: updatePartStatus, isIdle: isProgressIdle } =
+    useUserPartProgressQuery.updatePartStatus();
 
   const navigate = useNavigate();
 
@@ -44,7 +44,7 @@ export default function TotalResults({
     () => {
       experienceUpdate({ experience });
       !isCompleted(partStatus) &&
-        updateProgress({ partId, partStatus: 'IN_PROGRESS' });
+        updatePartStatus({ partId, partStatus: 'IN_PROGRESS' });
     },
     { delay: 1000, enabled: isSuccess }
   );


### PR DESCRIPTION
## 🔗 관련 이슈
#133 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용

백엔드 api가 몇몇 변경되면서 이를 수정하는 작업을 진행했습니다.

또한 기존 파트 진행도를 업데이트 후 진행도에 대한 쿼리를 초기화하지 않아 예전 데이터를 가져오는 경우를 방지하기 위해
쿼리 키를 조금 더 계층적으로 나누어 유저의 진행도에 대한 모든 쿼리를 초기화 가능하도록 수정하였습니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 유저 진행도 쿼리 키  계층 추가
- [ ] 파트 진행도 업데이트 api 변경


## 💬리뷰 요구사항 (선택사항)
