### PR TITLE
생명력 로직 버그수정

### DIFF
--- a/src/features/learn/queries.ts
+++ b/src/features/learn/queries.ts
@@ -1,21 +1,20 @@
 import { useSuspenseQuery, useInfiniteQuery } from '@tanstack/react-query';
 import sectionsApis from '@features/learn/apis';
 import type { SectionPagination } from '@features/learn/types';
+import { userKeys } from '@/features/user/queries';
 
 const sectionKeys = {
   all: ['sections'] as const,
   list: () => [...sectionKeys.all, 'list'] as const,
   detail: (id: number) => [...sectionKeys.all, 'detail', id] as const,
   paginated: () => [...sectionKeys.all, 'paginated'] as const,
-  userPaginated: () =>
-    ['users', 'me', ...sectionKeys.all, 'paginated'] as const,
 };
 
 // 무한 스크롤용(페이지네이션) 섹션 쿼리 생성 함수
 const createInfiniteSectionQuery = (
   queryKey:
     | ReturnType<typeof sectionKeys.paginated>
-    | ReturnType<typeof sectionKeys.userPaginated>,
+    | ReturnType<typeof userKeys.userPaginated>,
   apiFn: (cursor?: number) => Promise<SectionPagination>
 ) => {
   return () =>
@@ -51,7 +50,7 @@ export const useSectionPaginationQuery = {
     sectionsApis.getSectionsByPage
   ),
   getUserSectionsByPage: createInfiniteSectionQuery(
-    sectionKeys.userPaginated(),
+    userKeys.userPaginated(),
     sectionsApis.getUserSectionsByPage
   ),
 };

--- a/src/features/quiz/hooks.ts
+++ b/src/features/quiz/hooks.ts
@@ -1,11 +1,7 @@
 import { PartStatus } from '@/features/learn/types';
-import { useUserHpQuery } from '@/features/user/queries';
-import { isLoggedIn } from '@/features/user/service/authUtils';
-import useUserStore from '@/store/useUserStore';
 import hljs from 'highlight.js';
 import { DependencyList, useState, useLayoutEffect, useEffect } from 'react';
-import toast from 'react-hot-toast';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 /**
  * 주어진 코드 문자열을 하이라이트 처리된 HTML로 변환하는 React 커스텀 훅입니다.
@@ -73,29 +69,4 @@ export const useLocationQuizState = () => {
     partId: number;
     partStatus: PartStatus;
   };
-};
-
-type useHpUpdate = (isCorrect: boolean) => void;
-export const useHpUpdate: useHpUpdate = isCorrect => {
-  const { mutate: hpUpdate } = useUserHpQuery.updateHp();
-  const { data: userHp } = useUserHpQuery.getHpWhenLoggedIn();
-  const { user } = useUserStore();
-
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (Number(userHp?.hp) === 0) {
-      toast('목숨이 다 소진되었습니다.');
-      navigate('/');
-    }
-
-    if (isCorrect) return;
-
-    if (isLoggedIn(user) && userHp) {
-      hpUpdate({
-        hp: Number(userHp.hp) - 1,
-        hpStorage: userHp.hpStorage,
-      });
-    }
-  }, [isCorrect]);
 };

--- a/src/features/quiz/ui/QuizContainer.tsx
+++ b/src/features/quiz/ui/QuizContainer.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import useBeforeUnload from '@/hooks/useBeforeUnload';
 import useModal from '@hooks/useModal';
 import usePreloadImages from '@hooks/usePreloadImages';
-import useFunnel from '@hooks/useFunnel';
 import { SwitchCase, useUnmount } from '@modern-kit/react';
 import { noop } from '@modern-kit/utils';
 import { useClientQuizStore } from '@store/useClientQuizStore';
@@ -33,7 +32,7 @@ import {
   SubmitSection,
 } from '@/features/quiz/ui/styles';
 import withQuizzes from '@/features/quiz/hocs/withQuizzes';
-import { useHpUpdate } from '@/features/quiz/hooks';
+import { useHpUpdate } from '@/features/user/hooks';
 
 interface QuizProps {
   partStatus: PartStatus;
@@ -64,6 +63,7 @@ function QuizContainer({
   const isQuizFinished = isCorrectList.length === quizzes?.length;
 
   const [step, setStep] = useState<ModalType>('result');
+
   useEffect(() => {
     if (isCorrectList.length === 2 && !isLoggedIn(user)) {
       setStep('loginPrompt');

--- a/src/features/quiz/ui/QuizContainer.tsx
+++ b/src/features/quiz/ui/QuizContainer.tsx
@@ -149,7 +149,7 @@ function QuizContainer({
               <Result
                 partStatus={partStatus}
                 quizId={id}
-                isCorrect={isCorrectList[currentPage]}
+                isCorrect={!!isCorrectList[currentPage]}
                 answer={answer}
                 openModal={openModal}
                 closeModal={closeModal}

--- a/src/features/quiz/ui/Result.tsx
+++ b/src/features/quiz/ui/Result.tsx
@@ -7,7 +7,6 @@ import type { PartStatus } from '@features/learn/types';
 import type { Quiz } from '@features/quiz/types';
 import { isLoggedIn } from '@features/user/service/authUtils';
 import { isCompleted } from '@/features/quiz/utils';
-import { useHpUpdate } from '@/features/quiz/hooks';
 
 interface ResultProps {
   quizId: Quiz['id'];

--- a/src/features/user/hooks.ts
+++ b/src/features/user/hooks.ts
@@ -1,0 +1,32 @@
+import { useUserHpQuery } from '@/features/user/queries';
+import { isLoggedIn } from '@/features/user/service/authUtils';
+import useUserStore from '@/store/useUserStore';
+import { useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
+type useHpUpdate = (isCorrect: boolean) => void;
+export const useHpUpdate: useHpUpdate = isCorrect => {
+  const { mutate: hpUpdate } = useUserHpQuery.updateHp();
+  const { data: userHp } = useUserHpQuery.getHpWhenLoggedIn();
+  const { user } = useUserStore();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (Number(userHp?.hp) === 0) {
+      toast('목숨이 다 소진되었습니다.');
+      navigate('/');
+    }
+
+    if (isCorrect === undefined) return;
+
+    if (isCorrect) return;
+
+    if (isLoggedIn(user) && userHp) {
+      hpUpdate({
+        hp: Number(userHp.hp) - 1,
+        hpStorage: userHp.hpStorage,
+      });
+    }
+  }, [isCorrect]);
+};

--- a/src/features/user/hooks.ts
+++ b/src/features/user/hooks.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
-type useHpUpdate = (isCorrect: boolean) => void;
+type useHpUpdate = (isCorrect: boolean | undefined) => void;
 export const useHpUpdate: useHpUpdate = isCorrect => {
   const { mutate: hpUpdate } = useUserHpQuery.updateHp();
   const { data: userHp } = useUserHpQuery.getHpWhenLoggedIn();

--- a/src/features/user/queries.ts
+++ b/src/features/user/queries.ts
@@ -10,13 +10,14 @@ import type { Section, Part } from '@features/learn/types';
 import useUserStore from '@/store/useUserStore';
 import { isLoggedIn } from '@/features/user/service/authUtils';
 
-const userKeys = {
+export const userKeys = {
   all: ['users'] as const,
   me: () => [...userKeys.all, 'me'] as const,
   hp: () => [...userKeys.me(), 'hp'] as const,
   experience: () => [...userKeys.me(), 'experience'] as const,
   quizzes: () => [...userKeys.me(), 'quizzes'],
   partQuizzes: (partId: number) => [...userKeys.quizzes(), partId],
+  userPaginated: () => [...userKeys.me(), 'sections', 'paginated'] as const,
 
   progress: {
     root: () => [...userKeys.me(), 'progress'] as const,
@@ -146,7 +147,9 @@ export const useUserPartStatusQuery = {
       mutationFn: usersApis.patchPartStatus,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
-        queryClient.invalidateQueries({ queryKey: userKeys.me() });
+        queryClient.invalidateQueries({
+          queryKey: userKeys.userPaginated(),
+        });
       },
     });
   },
@@ -156,7 +159,9 @@ export const useUserPartStatusQuery = {
       mutationFn: usersApis.patchCompletedPartStatus,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
-        queryClient.invalidateQueries({ queryKey: userKeys.me() });
+        queryClient.invalidateQueries({
+          queryKey: userKeys.userPaginated(),
+        });
       },
     });
   },

--- a/src/features/user/queries.ts
+++ b/src/features/user/queries.ts
@@ -139,13 +139,14 @@ export const useUserPointQuery = {
   },
 };
 
-export const useUserPartProgressQuery = {
+export const useUserPartStatusQuery = {
   updatePartStatus: () => {
     const queryClient = useQueryClient();
     return useMutation({
       mutationFn: usersApis.patchPartStatus,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
+        queryClient.invalidateQueries({ queryKey: userKeys.me() });
       },
     });
   },
@@ -155,6 +156,7 @@ export const useUserPartProgressQuery = {
       mutationFn: usersApis.patchCompletedPartStatus,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.progress.root() });
+        queryClient.invalidateQueries({ queryKey: userKeys.me() });
       },
     });
   },

--- a/src/features/user/ui/PartClear.tsx
+++ b/src/features/user/ui/PartClear.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import * as S from '@features/quiz/ui/styles';
 import {
-  useUserPartProgressQuery,
+  useUserPartStatusQuery,
   useUserPointQuery,
 } from '@features/user/queries';
 import { getImageUrl } from '@utils/getImageUrl';
@@ -13,7 +13,7 @@ export default function PartClear({ partId }: PartClearProps) {
   const { mutate: updatePoint, isIdle: isPointIdle } =
     useUserPointQuery.updatePoint();
   const { mutate: updatePartStatus, isIdle: isProgressIdle } =
-    useUserPartProgressQuery.updateCompletedPartStatus();
+    useUserPartStatusQuery.updateCompletedPartStatus();
   const navigate = useNavigate();
   const handleNavigateToLearn = () => {
     updatePoint({ point: DEFAULT_POINT });

--- a/src/features/user/ui/TotalResults.tsx
+++ b/src/features/user/ui/TotalResults.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTimeout } from '@modern-kit/react';
 import {
   useUserExperienceQuery,
-  useUserPartProgressQuery,
+  useUserPartStatusQuery,
 } from '@features/user/queries';
 import ProgressBar from '@features/progress/ui/ProgressBar';
 import type { Quiz } from '@features/quiz/types';
@@ -32,7 +32,7 @@ export default function TotalResults({
   const { mutate: experienceUpdate, isIdle: isExperienceIdle } =
     useUserExperienceQuery.updateExperience();
   const { mutate: updatePartStatus, isIdle: isProgressIdle } =
-    useUserPartProgressQuery.updatePartStatus();
+    useUserPartStatusQuery.updatePartStatus();
 
   const navigate = useNavigate();
 

--- a/src/pages/quiz/Quiz.tsx
+++ b/src/pages/quiz/Quiz.tsx
@@ -1,12 +1,11 @@
 import Header from '@/common/layout/Header';
-import withQuizzes from '@/features/quiz/hocs/withQuizzes';
 import { useLocationQuizState } from '@/features/quiz/hooks';
 import QuizWithQuizzes from '@/features/quiz/ui/QuizContainer';
 import { AlignCenter, HeaderSection } from '@/pages/quiz/styles';
 
 export default function Quiz() {
   const { partId, partStatus } = useLocationQuizState();
-
+  console.log(partStatus);
   return (
     <AlignCenter>
       <HeaderSection>

--- a/src/pages/quiz/Quiz.tsx
+++ b/src/pages/quiz/Quiz.tsx
@@ -5,7 +5,7 @@ import { AlignCenter, HeaderSection } from '@/pages/quiz/styles';
 
 export default function Quiz() {
   const { partId, partStatus } = useLocationQuizState();
-  console.log(partStatus);
+
   return (
     <AlignCenter>
       <HeaderSection>

--- a/src/store/useClientQuizStore.ts
+++ b/src/store/useClientQuizStore.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand';
 interface State {
   currentPage: number;
   userResponseAnswer: string[];
-  isCorrectList: boolean[];
+  isCorrectList: (boolean | undefined)[];
 }
 interface Actions {
   nextPage: () => void;


### PR DESCRIPTION
## 🔗 관련 이슈
#139 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
뭐 하나 고치면 다른 버그가 터지네요....
처음부터 설계를 잘 했어야 했는데 아쉽습니다 😢😢😢😢😢😢😢😢

### 생명력 감소 수정
isCorrectList에 접근할때 답 입력 전에 접근해여 접속 시 생명력이 감소하는 버그 수정

### 파트 업데이트 수정
파트 상태 업데이트 후 파트 정보를 다시 가져오지 않아서 예전 서버의 값을 참조하던 문제를
상태 업데이트 후 progress  +section 정보를 초기화하도록 변경했습니다.

훅에서 현재 정답값을 받을 때 아직 초기화되지 않은 값이 들어와서 
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
