### PR TITLE
랭킹 페이지 로그인 후 새로고침 시 발생하는 버그 해결

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, bugFix/#144/Ranking_Page]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Docker
 
 on:
   push:
-    branches: [main, develop, bugFix/#144/Ranking_Page]
+    branches: [main, develop]
 
 env:
   DOCKER_IMAGE: ghcr.io/${{ github.actor }}/react-auto-deploy

--- a/src/features/ranking/ui/MyRank.tsx
+++ b/src/features/ranking/ui/MyRank.tsx
@@ -18,12 +18,12 @@ export default function MyRank({
   onRankingChange,
   onLoadingChange,
 }: MyRankProps) {
-  const { user } = useUserStore();
-
   // 자신의 랭킹 정보 (로그인한 경우만)
-  const { data, isLoading } = isLoggedIn(user)
-    ? useUserRankingQuery.getRanking(RANKING_OPTIONS[selectedOption].dataField)
-    : { data: null, isLoading: false };
+  const { data, isLoading } = useUserRankingQuery.getRanking(
+    RANKING_OPTIONS[selectedOption].dataField
+  );
+
+  const { user } = useUserStore();
 
   const ranking = data?.ranking ?? 0;
   const level = user?.level ?? 0;

--- a/src/features/user/queries.ts
+++ b/src/features/user/queries.ts
@@ -191,9 +191,11 @@ export const useUserProgressQuery = {
 
 export const useUserRankingQuery = {
   getRanking: (sort: RankingSort = 'level') => {
+    const { user } = useUserStore();
     return useQuery({
       queryKey: userKeys.ranking(sort),
       queryFn: () => usersApis.getRanking({ sort }),
+      enabled: isLoggedIn(user),
     });
   },
 };


### PR DESCRIPTION
## 🔗 관련 이슈
#144 

## 📝작업 내용
https://github.com/modern-agile-team/8term-coko-Front/pull/137#discussion_r1943017311
위 코멘트의 PR에서 저처럼 기존 조건부로 호출하는 방식이 아닌 useQuery의 enabled 사용하셨던 게 기억이 남아 혹시나 하고 적용해보니 해당 오류가 사라졌네요.

정확한 이유는 모르겠지만 enabeled로 로그인 했을 시에만 요청 가게끔 수정을 했기 때문에 MyRank 컴포넌트에서 useUserStore를 쿼리 호출하는 부분보다 밑에다 둘 수 있었고 이 부분이 아마 호출 순서에 영향이 가지 않았을까 싶습니다.

## 🔍 변경 사항

- [ ] 랭킹 페이지 리액트 호출 순서 오류 해결

## 💬리뷰 요구사항 (선택사항)
