### PR TITLE
생명력 sse 로직 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import QueryErrorBoundary from '@features/error/ui/QueryErrorBoundary';
 import { Suspense } from 'react';
 import Loader from '@common/layout/Loader';
 import Router from '@/route/Router';
+import SSEProvider from '@/common/layout/SSEProvider';
 
 function App() {
   useUserInitializer();
@@ -14,7 +15,9 @@ function App() {
       <Toaster position="top-right" />
       <QueryErrorBoundary>
         <Suspense fallback={<Loader />}>
-          <Router />
+          <SSEProvider>
+            <Router />
+          </SSEProvider>
         </Suspense>
       </QueryErrorBoundary>
     </>

--- a/src/common/layout/SSEProvider.tsx
+++ b/src/common/layout/SSEProvider.tsx
@@ -29,10 +29,13 @@ export default function SSEProvider({ children }: PropsWithChildren) {
     newEventSource.onmessage = (event: MessageEvent) => {
       try {
         const parsedData: SSEResponse = JSON.parse(event.data);
-        queryClient.invalidateQueries({ queryKey: userKeys.hp() });
-        toast.success(parsedData.message, {
-          icon: <HeaderIcon src={getImageUrl('과일바구니.svg')} />,
-        });
+
+        if (parsedData.type === 'hp_refilled') {
+          queryClient.invalidateQueries({ queryKey: userKeys.hp() });
+          toast.success(parsedData.message, {
+            icon: <HeaderIcon src={getImageUrl('과일바구니.svg')} />,
+          });
+        }
       } catch (err) {
         console.error('SSE 데이터 파싱 실패:');
         toast.error('SSE 데이터 처리 중 오류 발생');

--- a/src/common/layout/SSEProvider.tsx
+++ b/src/common/layout/SSEProvider.tsx
@@ -1,0 +1,77 @@
+import { HeaderIcon } from '@/common/ui/styles';
+import { MAX_RETRIES } from '@/features/user/constants';
+import { userKeys } from '@/features/user/queries';
+import { isLoggedIn } from '@/features/user/service/authUtils';
+import useUserStore from '@/store/useUserStore';
+import { getImageUrl } from '@/utils/getImageUrl';
+import { useQueryClient } from '@tanstack/react-query';
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+
+interface SSEResponse {
+  message: string;
+  timestamp: string;
+  type: string;
+}
+
+export default function SSEProvider({ children }: PropsWithChildren) {
+  const queryClient = useQueryClient();
+  const { user } = useUserStore();
+  const retryCount = useRef(0);
+  const [eventSource, setEventSource] = useState<EventSource | null>(null);
+
+  const connectSSE = () => {
+    const newEventSource = new EventSource(
+      `${import.meta.env.VITE_BASE_URL}/sse`,
+      { withCredentials: true }
+    );
+
+    newEventSource.onmessage = (event: MessageEvent) => {
+      try {
+        const parsedData: SSEResponse = JSON.parse(event.data);
+        queryClient.invalidateQueries({ queryKey: userKeys.hp() });
+        toast.success(parsedData.message, {
+          icon: <HeaderIcon src={getImageUrl('과일바구니.svg')} />,
+        });
+      } catch (err) {
+        console.error('SSE 데이터 파싱 실패:');
+        toast.error('SSE 데이터 처리 중 오류 발생');
+      }
+    };
+
+    newEventSource.onerror = () => {
+      console.error(`서버 연결 실패`);
+      toast.error('서버 연결에 문제가 발생했습니다.');
+
+      newEventSource.close();
+
+      if (retryCount.current < MAX_RETRIES) {
+        retryCount.current += 1;
+        setTimeout(() => {
+          console.log(`서버 연결 재시도`);
+          setEventSource(connectSSE());
+        }, 5000);
+      }
+    };
+
+    newEventSource.onopen = () => {
+      console.log('SSE 연결 성공');
+      retryCount.current = 0;
+    };
+
+    return newEventSource;
+  };
+
+  useEffect(() => {
+    if (isLoggedIn(user)) {
+      setEventSource(connectSSE());
+    }
+
+    return () => {
+      console.log('SSE 연결 해제');
+      eventSource?.close();
+    };
+  }, [queryClient]);
+
+  return children;
+}

--- a/src/features/user/apis.ts
+++ b/src/features/user/apis.ts
@@ -11,7 +11,7 @@ import type { Quiz } from '@features/quiz/types';
 import type { RankingSort } from '@features/ranking/types';
 import type { DailyQuestResponse } from '@features/quest/types';
 
-const usersApis = {
+export const usersApis = {
   putQuizzesProgress: ({
     quizId,
     body,
@@ -65,14 +65,6 @@ const usersApis = {
     await api.patch(`/users/me/parts/${params.partId}/status/completed`);
   },
 
-  getHp: async (): Promise<UserHp> => {
-    const response = await api.get('users/me/hp');
-    return response.data;
-  },
-
-  patchHp: async (params: Omit<UserHp, 'id'>): Promise<void> =>
-    await api.patch('/users/me/hp', params),
-
   getRanking: async (params: {
     sort: RankingSort;
   }): Promise<PersonalRanking> => {
@@ -101,4 +93,14 @@ const usersApis = {
   },
 };
 
-export default usersApis;
+export const userHpApi = {
+  getHp: async (): Promise<UserHp> => {
+    const response = await api.get('users/me/hp');
+    return response.data;
+  },
+
+  patchHp: async (): Promise<UserHp> => {
+    const response = await api.patch('/users/me/hp');
+    return response.data;
+  },
+};

--- a/src/features/user/constants.ts
+++ b/src/features/user/constants.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_POINT = 1500;
+
+export const MAX_RETRIES = 3;

--- a/src/features/user/hooks.ts
+++ b/src/features/user/hooks.ts
@@ -7,26 +7,20 @@ import { useNavigate } from 'react-router-dom';
 
 type useHpUpdate = (isCorrect: boolean | undefined) => void;
 export const useHpUpdate: useHpUpdate = isCorrect => {
-  const { mutate: hpUpdate } = useUserHpQuery.updateHp();
-  const { data: userHp } = useUserHpQuery.getHpWhenLoggedIn();
+  const { mutate: hpUpdate, data: userHp } = useUserHpQuery.updateHp();
   const { user } = useUserStore();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (Number(userHp?.hp) === 0) {
-      toast('목숨이 다 소진되었습니다.');
-      navigate('/');
+    if (userHp?.hp === 0) {
+      toast.error('생명력이 소진되었어요!');
+      navigate('/learn');
     }
-
     if (isCorrect === undefined) return;
-
     if (isCorrect) return;
 
-    if (isLoggedIn(user) && userHp) {
-      hpUpdate({
-        hp: Number(userHp.hp) - 1,
-        hpStorage: userHp.hpStorage,
-      });
+    if (isLoggedIn(user)) {
+      hpUpdate();
     }
   }, [isCorrect]);
 };

--- a/src/features/user/queries.ts
+++ b/src/features/user/queries.ts
@@ -4,7 +4,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from '@tanstack/react-query';
-import usersApis from '@features/user/apis';
+import { userHpApi, usersApis } from '@features/user/apis';
 import type { ExperiencedUser } from '@features/user/types';
 import type { Section, Part } from '@features/learn/types';
 import type { RankingSort } from '@features/ranking/types';
@@ -47,22 +47,15 @@ export const useUserHpQuery = {
   getHpWithSuspense: () => {
     return useSuspenseQuery({
       queryKey: userKeys.hp(),
-      queryFn: usersApis.getHp,
+      queryFn: userHpApi.getHp,
       retry: 0,
     });
   },
-  getHpWhenLoggedIn: () => {
-    const { user } = useUserStore();
-    return useQuery({
-      queryKey: userKeys.hp(),
-      queryFn: usersApis.getHp,
-      enabled: isLoggedIn(user),
-    });
-  },
+
   updateHp: () => {
     const queryClient = useQueryClient();
     return useMutation({
-      mutationFn: usersApis.patchHp,
+      mutationFn: userHpApi.patchHp,
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: userKeys.hp() });
       },

--- a/src/features/user/service/utils.ts
+++ b/src/features/user/service/utils.ts
@@ -1,3 +1,7 @@
+export const getCurrentDay = (): number => {
+  return new Date().getDate();
+};
+
 export const getCurrentYear = () => {
   const today = new Date();
   return today.getFullYear();

--- a/src/features/user/ui/AttendanceCalendar.tsx
+++ b/src/features/user/ui/AttendanceCalendar.tsx
@@ -4,6 +4,7 @@ import {
   getDayFromDate,
   getCurrentMonth,
   getCurrentYear,
+  getCurrentDay,
 } from '@/features/user/service/utils';
 import {
   AttendanceCalendarBoard,
@@ -32,7 +33,8 @@ export default function AttendanceCalendar() {
   useEffect(() => {
     if (!isUserAttendance) {
       recordAttendance(undefined, {
-        onSuccess: () => {
+        onSuccess: data => {
+          console.log(data);
           setIsTodayAttendance(true);
           toast.success('출석체크 성공!');
         },
@@ -56,7 +58,7 @@ export default function AttendanceCalendar() {
           {stampDaysMap[day] && (
             <AttendanceStamp
               src={getImageUrl('출석체크도장.svg')}
-              $isTodayAttendance={isTodayAttendance}
+              $isTodayAttendance={isTodayAttendance && day === getCurrentDay()}
             />
           )}
           <p>{day}</p>


### PR DESCRIPTION
## 🔗 관련 이슈
#161 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
![image](https://github.com/user-attachments/assets/4a1b5fc2-4eb1-4a7f-a09c-5c05b47bca25)
생명력이 회복 되었을 때 바로 사용자가 확인 가능하도록 sse 연결을 사용해서 알림 기능을 만들었습니다.
App컴포넌트에서 프로바이더`SSEProvider` 를 감싸주어 접속 시 연결합니다.
추후에 다른 이벤트가 발생해도 이를 사용하는 곳에서 또 연결하는 것 보다는 최초 연결 후 이벤트 타입에 따라 로직을 추가할 수 있도록 만들었습니다.

연결 실패 시 최대 3번 재요청을 보냅니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 생명럭 sse 구현

## 💬리뷰 요구사항 (선택사항)
