### PR TITLE
사용자의 파트 상태에 따라 정답 상태 업데이트 로직 개선

### DIFF
--- a/src/features/quiz/ui/Result.tsx
+++ b/src/features/quiz/ui/Result.tsx
@@ -36,11 +36,22 @@ export default function Result({
   const handleOnClick = () => {
     resetUserResponseAnswer();
     closeModal();
-    if (isLoggedIn(user) && !isCompleted(partStatus)) {
-      progressUpdate({
-        quizId,
-        body: { isCorrect },
-      });
+    //1. 사용자가 로그인 되어있는지 확인
+    if (isLoggedIn(user)) {
+      //2. 사용자의 파트 상태 확인
+      if (isCompleted(partStatus)) {
+        //3. 사용자의 파트 상태가 완료 상태라면 정답 상태 true로 업데이트
+        progressUpdate({
+          quizId,
+          body: { isCorrect: true },
+        });
+      } else {
+        //4. 사용자의 파트 상태가 완료 상태가 아니라면 정답 상태에 따라 업데이트
+        progressUpdate({
+          quizId,
+          body: { isCorrect },
+        });
+      }
     }
     if (isQuizFinished) {
       onNext();

--- a/src/features/user/constants.ts
+++ b/src/features/user/constants.ts
@@ -7,3 +7,10 @@ export const OPINIONS_OPTIONS = [
   { label: '기능 추가', id: 2 },
   { label: '직접 입력', id: 3 },
 ] as const;
+
+export const ERROR_MESSAGES = {
+  REQUIRED_CONTENT: '내용은 필수 입력 사항입니다.',
+  CONTENT_TOO_LONG: '내용은 255자 이하로 입력해주세요.',
+  REQUIRED_TITLE: '제목을 입력해주세요.',
+  REQUIRED_QUIZ: '퀴즈를 선택해주세요.',
+} as const;

--- a/src/features/user/ui/OpinionsModal.tsx
+++ b/src/features/user/ui/OpinionsModal.tsx
@@ -2,7 +2,7 @@ import SortDropdown from '@/common/layout/SortDropdown';
 import Select from '@/features/intro/ui/Select';
 import { useLocationQuizState } from '@/features/quiz/hooks';
 import { Quiz } from '@/features/quiz/types';
-import { OPINIONS_OPTIONS } from '@/features/user/constants';
+import { ERROR_MESSAGES, OPINIONS_OPTIONS } from '@/features/user/constants';
 import { useUserOpinionsQuery } from '@/features/user/queries';
 import {
   ContentWrapper,
@@ -37,35 +37,49 @@ export default function OpinionsModal({
 
   const { mutate: createOpinions } = useUserOpinionsQuery.createOpinions();
 
-  const handleSubmit = () => {
+  const getTitle = () => {
+    const titleMap: Record<string, string> = {
+      '직접 입력': customTitle,
+      퀴즈: quizInfo,
+    };
+
+    return titleMap[selectedOption] || selectedOption;
+  };
+
+  const getErrorMessage = () => {
     if (!content) {
-      setError('내용은 필수 입력 사항입니다.');
-      return;
+      return ERROR_MESSAGES.REQUIRED_CONTENT;
     }
     if (content.length >= 255) {
-      setError('내용은 255자 이하로 입력해주세요.');
-      return;
+      return ERROR_MESSAGES.CONTENT_TOO_LONG;
     }
 
-    if (selectedOption === '직접 입력') {
-      if (!customTitle) {
-        setError('제목을 입력해주세요.');
-        return;
-      }
-    } else if (selectedOption === '퀴즈') {
-      if (!quizInfo) {
-        setError('퀴즈를 선택해주세요.');
-        return;
-      }
+    if (selectedOption === '직접 입력' && !customTitle) {
+      return ERROR_MESSAGES.REQUIRED_TITLE;
     }
-    let title = '';
-    if (selectedOption === '직접 입력') {
-      title = customTitle;
-    } else if (selectedOption === '퀴즈') {
-      title = quizInfo;
-    } else {
-      title = selectedOption;
+
+    if (selectedOption === '퀴즈' && !quizInfo) {
+      return ERROR_MESSAGES.REQUIRED_QUIZ;
     }
+
+    return null;
+  };
+
+  const validation = () => {
+    const errorMessage = getErrorMessage();
+
+    if (errorMessage) {
+      setError(errorMessage);
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = () => {
+    if (!validation()) {
+      return;
+    }
+    const title = getTitle();
 
     createOpinions(
       {

--- a/src/features/user/ui/OpinionsModal.tsx
+++ b/src/features/user/ui/OpinionsModal.tsx
@@ -58,9 +58,18 @@ export default function OpinionsModal({
         return;
       }
     }
+    let title = '';
+    if (selectedOption === '직접 입력') {
+      title = customTitle;
+    } else if (selectedOption === '퀴즈') {
+      title = quizInfo;
+    } else {
+      title = selectedOption;
+    }
+
     createOpinions(
       {
-        title: customTitle,
+        title,
         content,
       },
       {
@@ -70,7 +79,6 @@ export default function OpinionsModal({
         },
       }
     );
-    return;
   };
 
   return (


### PR DESCRIPTION
## 🔗 관련 이슈
#191 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## 📝작업 내용
백엔드에서 진행도 업데이트를 트리거로 퀘스트 클리어를 감지해서
원래 파트 클리어 상태면 추가적으로 진행도 업데이트 요청을 보내지 않았는데
파트 클리어 상태일때도 이미 다 맞춘문제니까 해당 문제를 true로 요청을 보내는 로직을 추가했습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🔍 변경 사항

- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 💬리뷰 요구사항 (선택사항)
